### PR TITLE
Explicitly ask for clang in hints/macosx.

### DIFF
--- a/sys/unix/hints/macosx
+++ b/sys/unix/hints/macosx
@@ -47,7 +47,7 @@ GAMEGRP  = $(GAMEUID)
 
 
 #CC=gcc -W -Wimplicit -Wreturn-type -Wunused -Wformat -Wswitch -Wshadow -Wcast-qual -Wwrite-strings -DGCC_WARN
-CC=gcc -Wall -Wextra -Wno-missing-field-initializers -Wimplicit -Wreturn-type -Wunused -Wformat -Wswitch -Wshadow -Wwrite-strings -DGCC_WARN
+CC=clang -Wall -Wextra -Wno-missing-field-initializers -Wimplicit -Wreturn-type -Wunused -Wformat -Wswitch -Wshadow -Wwrite-strings -DGCC_WARN
 
 #
 # You shouldn't need to change anything below here.


### PR DESCRIPTION
Alternative: Output of `xcodebuild -find cc`, but we will call `make`
anyway hoping it's the right version.

Hope this might fix #28 .