### PR TITLE
Remove unnecessary check in CI

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -22,9 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Check token
-      run: |
-        [ -n "${{ secrets.DOCKERHUB_TOKEN }}" ]
     - name: Build and push image
       uses: docker/build-push-action@v1
       with:
@@ -57,9 +54,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Check token
-      run: |
-        [ -n "${{ secrets.DECKERHUB_TOKEN }}" ]
     - name: Build and push image
       uses: docker/build-push-action@v1
       with:


### PR DESCRIPTION
Sigh. Left a debugging instruction which stops one of the docker CI pushes. Removing it here.