### PR TITLE
Clone repository recursively in CI when building docker images

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -13,7 +13,8 @@ on:
       - "*"
     branches:
       - master
-    pull_request:
+  pull_request:
+    paths:
       - "docker/Dockerfile*"
   release:
     types: [released]

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -30,8 +30,6 @@ jobs:
     - name: Build image
       uses: docker/build-push-action@v1
       with:
-        username: edran
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: fairnle/nle
         dockerfile: docker/Dockerfile
         tags: dev
@@ -78,8 +76,6 @@ jobs:
     - name: Build image
       uses: docker/build-push-action@v1
       with:
-        username: edran
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: fairnle/nle-xenial
         dockerfile: docker/Dockerfile
         tags: dev

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -13,6 +13,8 @@ on:
       - "*"
     branches:
       - master
+    pull_request:
+      - "docker/Dockerfile*"
   release:
     types: [released]
 
@@ -22,7 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Build and push image
+      with:
+        submodules: true
+    - name: Build image
       uses: docker/build-push-action@v1
       with:
         username: edran
@@ -32,6 +36,19 @@ jobs:
         tags: dev
         tag_with_sha: true
         add_git_labels: true
+        push: false
+    - name: Push image
+      if: github.ref == 'master' || (github.event_name == 'release' && github.even.action == 'released')
+      uses: docker/build-push-action@v1
+      with:
+        username: edran
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        repository: fairnle/nle
+        dockerfile: docker/Dockerfile
+        tags: dev
+        tag_with_sha: true
+        add_git_labels: true
+        push: true
     - name: Check version matches release tag
       if: github.event_name == 'release' && github.event.action == 'released'
       run: |
@@ -48,13 +65,16 @@ jobs:
         dockerfile: docker/Dockerfile
         tags: ${{ github.event.release.tag_name }},stable
         add_git_labels: true
+        push: true
 
   xenial:
     name: Build and publish xenial image
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Build and push image
+      with:
+        submodules: true
+    - name: Build image
       uses: docker/build-push-action@v1
       with:
         username: edran
@@ -64,6 +84,19 @@ jobs:
         tags: dev
         tag_with_sha: true
         add_git_labels: true
+        push: false
+    - name: Push image
+      if: github.ref == 'master' || (github.event_name == 'release' && github.even.action == 'released')
+      uses: docker/build-push-action@v1
+      with:
+        username: edran
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        repository: fairnle/nle-xenial
+        dockerfile: docker/Dockerfile
+        tags: dev
+        tag_with_sha: true
+        add_git_labels: true
+        push: true
     - name: Check version matches release tag
       if: github.event_name == 'release' && github.event.action == 'released'
       run: |
@@ -80,4 +113,5 @@ jobs:
         dockerfile: docker/Dockerfile-xenial
         tags: ${{ github.event.release.tag_name }}
         add_git_labels: true
+        push: true
 ...

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,6 @@ RUN curl -fSL "https://github.com/google/flatbuffers/archive/v1.12.0.tar.gz" -o 
     && make install \
     && cp src/idl_parser.cpp src/idl_gen_text.cpp /usr/local/include/flatbuffers
 
-
 WORKDIR /opt/conda_setup
 
 RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
@@ -59,6 +58,7 @@ ENV PATH /opt/conda/bin:$PATH
 RUN python -m pip install --upgrade pip ipython ipdb
 
 WORKDIR /opt/nle
+
 COPY . .
 
 RUN pip install ".[all]"

--- a/docker/Dockerfile-xenial
+++ b/docker/Dockerfile-xenial
@@ -47,7 +47,6 @@ RUN curl -fSL "https://github.com/google/flatbuffers/archive/v1.12.0.tar.gz" -o 
     && make install \
     && cp src/idl_parser.cpp src/idl_gen_text.cpp /usr/local/include/flatbuffers
 
-
 WORKDIR /opt/conda_setup
 
 RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
@@ -60,8 +59,8 @@ ENV PATH /opt/conda/bin:$PATH
 RUN python -m pip install --upgrade pip ipython ipdb
 
 WORKDIR /opt/nle
-COPY . .
 
+COPY . .
 
 RUN pip install ".[all]"
 


### PR DESCRIPTION
And build images on PR events too, so that next time we will know if the workflow is broken.

Previous PR broke CI on master, since the docker image workflows didn't get run. This PR allows to run _some_ of the workflow, up till before pushing any image, on PR events. Hopefully this will prevent any other such mistakes.

As a good side effect, this PR also allows any PR tracking a branch of a forked repo to build docker images (since the jobs won't explode anymore because of the dockerhub not being available in the CI context).