### PR TITLE
Install HACKDIR into package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,4 @@ dmypy.json
 nle/version.py
 nle_data/
 nle/fbs/
+nle/nethackdir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,13 @@ file(STRINGS "version.txt" NLE_VERSION)
 project(nle VERSION ${NLE_VERSION})
 message(STATUS "Building nle backend version: ${NLE_VERSION}")
 
-# This is set to build_lib in build_ext, since we use it to export the python
-# interfaces into the right package.
+# We use this to decide where the root of the nle/ package is. Normally it
+# shouldn't be needed, but sometimes (e.g. when using setuptools) we are
+# generating some of the files outside of the original package path.
 set(PYTHON_SRC_PARENT
     ${nle_SOURCE_DIR}
     CACHE STRING "Directory containing the nle package files")
 
-# TODO(NN): we should be at least XDG compliant
 set(HACKDIR
     "$ENV{HOME}/nethackdir"
     CACHE STRING "Configuration files for nethack")

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ pip install nle
 NOTE: If you want to extend / develop NLE, please install the package as follows:
 
 ``` bash
-$ git clone git@github.com:facebookresearch/nle
+$ git clone https://github.com/facebookresearch/nle --recursive
 $ pip install -e ".[dev]"
 $ pre-commit install
 ```

--- a/doc/nle/source/getting_started.rst
+++ b/doc/nle/source/getting_started.rst
@@ -48,7 +48,7 @@ Optionally, one can clone the repository and install the package manually.
 
 .. code-block:: bash
 
-   $ git clone https://github.com/facebookresearch/nle
+   $ git clone https://github.com/facebookresearch/nle --recursive
    $ conda activate nledev
    $ pip install .
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,6 +35,7 @@ version of `nle`, following a specific templates:
 To build any of them (e.g. the main `Dockerfile`) do:
 
 ```bash
-# in the repository root
+$ git clone https://github.com/facebookresearch/nle --recursive
+$ cd nle
 $ docker build -f docker/Dockerfile . -t nle:latest
 ```

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -2,8 +2,8 @@
 import functools
 import logging
 import os
+import pkg_resources
 import shutil
-import sys
 import tempfile
 import time
 import warnings
@@ -46,13 +46,8 @@ NETHACKOPTIONS = [
     "pickup_burden:unencumbered",
 ]
 
-HACKDIR = os.getenv("HACKDIR", os.path.join(sys.base_prefix, "nethackdir"))
+HACKDIR = os.getenv("HACKDIR", pkg_resources.resource_filename("nle", "nethackdir"))
 EXECUTABLE = os.path.join(HACKDIR, "nethack")
-
-if not os.path.exists(EXECUTABLE):
-    raise FileNotFoundError(
-        "Couldn't run nethack in %s as file doesn't exist" % EXECUTABLE
-    )
 
 
 def _exec_nethack(playername, hackdir, seeds=None, options=NETHACKOPTIONS):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ import sys
 import setuptools
 import setuptools.command.build_ext
 import setuptools.command.build_py
-import setuptools.command.install
 
 
 class BuildPy(setuptools.command.build_py.build_py):
@@ -32,12 +31,11 @@ class BuildPy(setuptools.command.build_py.build_py):
 class CMakeBuild(setuptools.command.build_ext.build_ext):
     def run(self):
         build_lib_path = pathlib.Path(self.build_lib).resolve()
-
         src_orig_path = pathlib.Path(__file__).parent.resolve().resolve()
         build_path = build_lib_path.parent.joinpath("nlehack")
+        hackdir_path = os.getenv("HACKDIR", src_orig_path.joinpath("nle", "nethackdir"))
 
         os.makedirs(build_path, exist_ok=True)
-        hackdir_path = os.getenv("HACKDIR", src_orig_path.joinpath("nle", "nethackdir"))
 
         cmake_cmd = [
             "cmake",
@@ -134,7 +132,6 @@ if __name__ == "__main__":
         packages=packages,
         ext_modules=[setuptools.Extension("nlehack", sources=[])],
         cmdclass={"build_ext": CMakeBuild, "build_py": BuildPy},
-        # cmdclass={"build_py": BuildPy, "install_data": InstallData, "install": Install},
         setup_requires=["pybind11>=2.2"],
         install_requires=[
             "pybind11>=2.2",


### PR DESCRIPTION
This PR modifies `setup.py` to install `HACKDIR` into the package, allowing to use `pkg_resources` to find it at runtime, as well as allowing `pip` to remove it when uninstalling the package.

When installing the package in editable mode, `HACKDIR` will be equal to `nle/nethackdir`.