### PR TITLE
Fix lodash version due to GHSA-p6mc-m468-83gw.

### DIFF
--- a/nle/dashboard/package-lock.json
+++ b/nle/dashboard/package-lock.json
@@ -397,7 +397,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.14",
+        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",


### PR DESCRIPTION
The gift that keeps giving. Why do we require dozens of npm packages?

Reference(s):
https://www.npmjs.com/advisories/1523
https://github.com/advisories/GHSA-p6mc-m468-83gw