### PR TITLE
Enable chars, colors, specials as observation tensors.

### DIFF
--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -98,6 +98,21 @@ class TestGymEnv:
         obs = env.reset()
         assert env.observation_space.contains(obs)
 
+    def test_chars_colors_specials(self, env_name):
+        env = gym.make(
+            env_name, observation_keys=("chars", "colors", "specials", "status")
+        )
+        obs = env.reset()
+
+        assert "specials" in obs
+        x, y = obs["status"][:2]
+
+        # That's where you're @.
+        assert obs["chars"][y, x] == ord("@")
+
+        # You're bright (4th bit, 8) white (7), too.
+        assert obs["colors"][y, x] == 8 ^ 7
+
 
 @pytest.mark.parametrize("env_name", get_nethack_env_ids())
 @pytest.mark.parametrize("rollout_len", [100])

--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -34,6 +34,7 @@ def rollout_env(env, max_rollout_len):
 
     step = 0
     while True:
+        step += 1
         a = env.action_space.sample()
         obs, reward, done, info = env.step(a)
         assert env.observation_space.contains(obs)


### PR DESCRIPTION
This adds "chars", "colors", and "specials" as observation keys. The latter is an xor'ed version of

```c
#define MG_CORPSE  0x01
#define MG_INVIS   0x02
#define MG_DETECT  0x04
#define MG_PET     0x08
#define MG_RIDDEN  0x10
#define MG_STATUE  0x20
#define MG_OBJPILE 0x40  /* more than one stack of objects */
#define MG_BW_LAVA 0x80  /* 'black & white lava': highlight lava if it
                            can't be distringuished from water by color */
```
(see hack.h)

This PR adds them as individual uint8 tensors. We could also return something of shape [3, DUNGEON_HEIGHT, DUNGEON_WIDTH]?