### PR TITLE
Very important fix: nhdat did not contain all files necessary.

### DIFF
--- a/dat/CMakeLists.txt
+++ b/dat/CMakeLists.txt
@@ -1,4 +1,10 @@
+# TODO: This creates lots of files in ${NLE_DAT}, i.e. in the source dir. We
+# should create files in the binary dir only. NetHack's utils require their
+# arguments to be in the same local directory, so this requires copying files
+# from ${NLE_DAT} to ${NLE_DAT_GEN}
+
 set(VARDATND) # NOTE: this is empty for us
+
 set(VARDATD
     bogusmon
     data
@@ -209,9 +215,9 @@ set(ALL_DAT_NOTGEN
     opthelp
     wizhelp)
 
-# We transform these as we use them later
-list(TRANSFORM QUEST_LEVELS PREPEND ${NLE_DAT}/)
-list(TRANSFORM SPECIAL_LEVELS PREPEND ${NLE_DAT}/)
+set(PLAIN_LEVS_GEN ${LEVS_GEN})
+
+# We transform these as we use them later.
 list(TRANSFORM DAT PREPEND ${NLE_DAT}/)
 list(TRANSFORM LEVS_GEN PREPEND ${NLE_DAT_GEN}/)
 
@@ -278,13 +284,15 @@ add_custom_command(
   DEPENDS lev_comp
   OUTPUT spec_levs
   COMMAND $<TARGET_FILE:lev_comp> ${SPECIAL_LEVELS}
-  COMMAND ${CMAKE_COMMAND} -E touch spec_levs)
+  COMMAND ${CMAKE_COMMAND} -E touch spec_levs
+  WORKING_DIRECTORY ${NLE_DAT})
 
 add_custom_command(
   DEPENDS lev_comp
   OUTPUT quest_levs
   COMMAND $<TARGET_FILE:lev_comp> ${QUEST_LEVELS}
-  COMMAND ${CMAKE_COMMAND} -E touch quest_levs)
+  COMMAND ${CMAKE_COMMAND} -E touch quest_levs
+  WORKING_DIRECTORY ${NLE_DAT})
 
 add_custom_command(
   OUTPUT perm record logfile xlogfile sysconf
@@ -298,7 +306,7 @@ add_custom_command(
   # originally this (technically) only depended on options
   DEPENDS dlb options ${DATDLB}
   OUTPUT ${NLE_DAT}/nhdat
-  COMMAND LC_ALL=C $<TARGET_FILE:dlb> cf nhdat ${DATDLB}
+  COMMAND LC_ALL=C $<TARGET_FILE:dlb> cf nhdat ${DATDLB} ${PLAIN_LEVS_GEN}
   WORKING_DIRECTORY ${NLE_DAT})
 
 set(NLE_DAT_OUTPUT_MOVED ${NLE_DAT_OUTPUT})

--- a/dat/CMakeLists.txt
+++ b/dat/CMakeLists.txt
@@ -284,14 +284,14 @@ add_custom_command(
   DEPENDS lev_comp
   OUTPUT spec_levs
   COMMAND $<TARGET_FILE:lev_comp> ${SPECIAL_LEVELS}
-  COMMAND ${CMAKE_COMMAND} -E touch spec_levs
+  COMMAND ${CMAKE_COMMAND} -E touch ${NLE_DAT_GEN}/spec_levs
   WORKING_DIRECTORY ${NLE_DAT})
 
 add_custom_command(
   DEPENDS lev_comp
   OUTPUT quest_levs
   COMMAND $<TARGET_FILE:lev_comp> ${QUEST_LEVELS}
-  COMMAND ${CMAKE_COMMAND} -E touch quest_levs
+  COMMAND ${CMAKE_COMMAND} -E touch ${NLE_DAT_GEN}/quest_levs
   WORKING_DIRECTORY ${NLE_DAT})
 
 add_custom_command(

--- a/dat/CMakeLists.txt
+++ b/dat/CMakeLists.txt
@@ -219,17 +219,9 @@ set(PLAIN_LEVS_GEN ${LEVS_GEN})
 
 # We transform these as we use them later.
 list(TRANSFORM DAT PREPEND ${NLE_DAT}/)
-list(TRANSFORM LEVS_GEN PREPEND ${NLE_DAT_GEN}/)
+list(TRANSFORM LEVS_GEN PREPEND ${NLE_DAT}/)
 
-set(NLE_DAT_GEN_OUTPUT
-    ${NLE_DAT_OUTPUT}
-    spec_levs
-    quest_levs
-    perm
-    record
-    logfile
-    xlogfile
-    sysconf)
+set(NLE_DAT_GEN_OUTPUT ${NLE_DAT_OUTPUT} perm record logfile xlogfile sysconf)
 list(TRANSFORM NLE_DAT_GEN_OUTPUT PREPEND ${NLE_DAT_GEN}/)
 
 add_custom_command(
@@ -282,16 +274,9 @@ add_custom_command(
 
 add_custom_command(
   DEPENDS lev_comp
-  OUTPUT spec_levs
+  OUTPUT ${LEVS_GEN}
   COMMAND $<TARGET_FILE:lev_comp> ${SPECIAL_LEVELS}
-  COMMAND ${CMAKE_COMMAND} -E touch ${NLE_DAT_GEN}/spec_levs
-  WORKING_DIRECTORY ${NLE_DAT})
-
-add_custom_command(
-  DEPENDS lev_comp
-  OUTPUT quest_levs
   COMMAND $<TARGET_FILE:lev_comp> ${QUEST_LEVELS}
-  COMMAND ${CMAKE_COMMAND} -E touch ${NLE_DAT_GEN}/quest_levs
   WORKING_DIRECTORY ${NLE_DAT})
 
 add_custom_command(
@@ -304,7 +289,7 @@ add_custom_command(
 # We also assume that dat/options contains librarian (since we build with -DDLB)
 add_custom_command(
   # originally this (technically) only depended on options
-  DEPENDS dlb options ${DATDLB}
+  DEPENDS dlb options ${DATDLB} ${LEVS_GEN}
   OUTPUT ${NLE_DAT}/nhdat
   COMMAND LC_ALL=C $<TARGET_FILE:dlb> cf nhdat ${DATDLB} ${PLAIN_LEVS_GEN}
   WORKING_DIRECTORY ${NLE_DAT})


### PR DESCRIPTION
**Previously, we had a too-small `nhdat` file and the game would crash or otherwise get into a bad state as soon as we entered e.g. the Gnomish mines.**

This has been the case since we switched to cmake, but it wasn't easy to detect as we need agents that get as far first.

This fixes the cmake logic to produce a `nhdat` with all required files.

**However**, I don't necessarily like that we build everything in the source directory. We should fix dat/CMakeLists.txt to copy the source dat/ directory into the build directory and run all commands there. I suspect this may make the logic in this file easier.
