### PR TITLE
Add NUM_OBJECTS and nethack.MAXEXPCHARS again.

### DIFF
--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -249,6 +249,7 @@ PYBIND11_MODULE(_pynethack, m)
     mn.attr("MAXWIN") = py::int_(20);
 
     mn.attr("NUMMONS") = py::int_(NUMMONS);
+    mn.attr("NUM_OBJECTS") = py::int_(NUM_OBJECTS);
 
     // Glyph array offsets. This is what the glyph_is_* functions
     // are based on, see display.h.
@@ -270,6 +271,7 @@ PYBIND11_MODULE(_pynethack, m)
     mn.attr("NO_GLYPH") = py::int_(NO_GLYPH);
     mn.attr("GLYPH_INVISIBLE") = py::int_(GLYPH_INVISIBLE);
 
+    mn.attr("MAXEXPCHARS") = py::int_(MAXEXPCHARS);
     mn.attr("MAXPCHARS") = py::int_(static_cast<int>(MAXPCHARS));
     mn.attr("EXPL_MAX") = py::int_(static_cast<int>(EXPL_MAX));
     mn.attr("NUM_ZAP") = py::int_(static_cast<int>(NUM_ZAP));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#69 Add NUM_OBJECTS and nethack.MAXEXPCHARS again.**
* #68 Add license line to new files.
* #67 Fix example agent to work with libnethack-style observations.

It got removed inadvertently.