### PR TITLE
Re-add inventory: Add inv_glyphs observation.

### DIFF
--- a/include/nleobs.h
+++ b/include/nleobs.h
@@ -5,6 +5,7 @@
 #define NLE_BLSTATS_SIZE 25
 #define NLE_PROGRAM_STATE_SIZE 6
 #define NLE_INTERNAL_SIZE 7
+#define NLE_INVENTORY_SIZE 55
 
 typedef struct nle_observation {
     int action;
@@ -18,6 +19,7 @@ typedef struct nle_observation {
     long *blstats;           /* NLE_BLSTATS_SIZE */
     int *program_state;      /* NLE_PROGRAM_STATE_SIZE */
     int *internal;           /* NLE_INTERNAL_SIZE */
+    short *inv_glyphs;       /* NLE_INVENTORY_SIZE */
 } nle_obs;
 
 typedef struct {

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -17,6 +17,7 @@ BLSTATS_SHAPE = (_pynethack.nethack.NLE_BLSTATS_SIZE,)
 MESSAGE_SHAPE = (256,)
 PROGRAM_STATE_SHAPE = (_pynethack.nethack.NLE_PROGRAM_STATE_SIZE,)
 INTERNAL_SHAPE = (_pynethack.nethack.NLE_INTERNAL_SIZE,)
+INV_GLYPHS_SHAPE = (_pynethack.nethack.NLE_INVENTORY_SIZE,)
 
 OBSERVATION_DESC = {
     "glyphs": dict(shape=DUNGEON_SHAPE, dtype=np.int16),
@@ -27,6 +28,7 @@ OBSERVATION_DESC = {
     "message": dict(shape=MESSAGE_SHAPE, dtype=np.uint8),
     "program_state": dict(shape=PROGRAM_STATE_SHAPE, dtype=np.int32),
     "internal": dict(shape=INTERNAL_SHAPE, dtype=np.int32),
+    "inv_glyphs": dict(shape=INV_GLYPHS_SHAPE, dtype=np.int16),
 }
 
 

--- a/nle/scripts/test_raw_nethack.py
+++ b/nle/scripts/test_raw_nethack.py
@@ -8,7 +8,7 @@ import sys
 from nle import nethack
 
 
-NO_SELF_PLAY = 2
+SELF_PLAY_EPISODES = 2
 
 
 @contextlib.contextmanager
@@ -45,7 +45,9 @@ def main():
         89,
     ]
 
-    nle = nethack.Nethack(observation_keys=("chars", "blstats", "message"))
+    nle = nethack.Nethack(
+        observation_keys=("chars", "blstats", "message", "inv_glyphs")
+    )
     nle.reset()
 
     nle.step(ord("y"))
@@ -81,19 +83,22 @@ def main():
 
     print("Finished after %i steps. Mean sps: %f" % (steps, mean_sps))
 
-    for i in range(NO_SELF_PLAY):
+    for i in range(SELF_PLAY_EPISODES):
         print("Starting self-play episode", i)
-        chars, blstats, message = nle.reset()
+        chars, blstats, message, inv_glyphs = nle.reset()
         done = False
         while not done:
             message = bytes(message)
             print(message)
+            print(inv_glyphs)
             for line in chars:
                 print(line.tobytes().decode("utf-8"))
             print(blstats)
             try:
                 with no_echo():
-                    (chars, blstats, message), done = nle.step(ord(sys.stdin.read(1)))
+                    (chars, blstats, message, inv_glyphs), done = nle.step(
+                        ord(sys.stdin.read(1))
+                    )
             except KeyboardInterrupt:
                 break
 

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -112,7 +112,8 @@ class Nethack
     void
     set_buffers(py::object glyphs, py::object chars, py::object colors,
                 py::object specials, py::object blstats, py::object message,
-                py::object program_state, py::object internal)
+                py::object program_state, py::object internal,
+                py::object inv_glyphs)
     {
         std::vector<ssize_t> dungeon{ ROWNO, COLNO - 1 };
         obs_.glyphs = checked_conversion<int16_t>(std::move(glyphs), dungeon);
@@ -128,6 +129,8 @@ class Nethack
             std::move(program_state), { NLE_PROGRAM_STATE_SIZE });
         obs_.internal = checked_conversion<int>(std::move(internal),
                                                 { NLE_INTERNAL_SIZE });
+        obs_.inv_glyphs = checked_conversion<int16_t>(std::move(inv_glyphs),
+                                                      { NLE_INVENTORY_SIZE });
     }
 
     void
@@ -218,11 +221,12 @@ PYBIND11_MODULE(_pynethack, m)
              py::arg("colors") = py::none(), py::arg("specials") = py::none(),
              py::arg("blstats") = py::none(), py::arg("message") = py::none(),
              py::arg("program_state") = py::none(),
-             py::arg("internal") = py::none(), py::keep_alive<1, 2>(),
+             py::arg("internal") = py::none(),
+             py::arg("inv_glyphs") = py::none(), py::keep_alive<1, 2>(),
              py::keep_alive<1, 3>(), py::keep_alive<1, 4>(),
              py::keep_alive<1, 5>(), py::keep_alive<1, 6>(),
              py::keep_alive<1, 7>(), py::keep_alive<1, 8>(),
-             py::keep_alive<1, 9>())
+             py::keep_alive<1, 9>(), py::keep_alive<1, 10>())
         .def("close", &Nethack::close)
         .def("set_initial_seeds", &Nethack::set_initial_seeds)
         .def("set_seeds", &Nethack::set_seeds)
@@ -236,6 +240,7 @@ PYBIND11_MODULE(_pynethack, m)
     mn.attr("NLE_BLSTATS_SIZE") = py::int_(NLE_BLSTATS_SIZE);
     mn.attr("NLE_PROGRAM_STATE_SIZE") = py::int_(NLE_PROGRAM_STATE_SIZE);
     mn.attr("NLE_INTERNAL_SIZE") = py::int_(NLE_INTERNAL_SIZE);
+    mn.attr("NLE_INVENTORY_SIZE") = py::int_(NLE_INVENTORY_SIZE);
 
     /* NetHack constants specific constants. */
     mn.attr("NHW_MESSAGE") = py::int_(NHW_MESSAGE);

--- a/win/rl/winrl.cc
+++ b/win/rl/winrl.cc
@@ -358,6 +358,15 @@ NetHackRL::fill_obs(nle_obs *obs)
 
         std::memcpy(obs->blstats, &blstats[0], sizeof(blstats));
     }
+    if (obs->inv_glyphs) {
+        int i = 0;
+        for (const struct obj *otmp = invent; otmp; otmp = otmp->nobj) {
+            obs->inv_glyphs[i++] = obj_to_glyph(otmp, rn2_on_display_rng);
+        }
+        for (; i < NLE_INVENTORY_SIZE; ++i) {
+            obs->inv_glyphs[i] = NO_GLYPH;
+        }
+    }
 }
 
 int


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77 Bump version to 0.5.1.
* #76 Update lint_python workflow to print diff when black failed.
* #75 Add inv_* observations to base.py.
* #74 Handle keep_alive logic explicitly.
* #73 Add inv_strs observation.
* #72 Use update_inventory for inventory observations.
* #71 Add inv_letters and inv_oclasses observations.
* **#70 Re-add inventory: Add inv_glyphs observation.**

