### PR TITLE
Add inv_strs observation.

### DIFF
--- a/include/nleobs.h
+++ b/include/nleobs.h
@@ -6,20 +6,23 @@
 #define NLE_PROGRAM_STATE_SIZE 6
 #define NLE_INTERNAL_SIZE 7
 #define NLE_INVENTORY_SIZE 55
+#define NLE_INVENTORY_STR_LENGTH 80
 
 typedef struct nle_observation {
     int action;
     int done;
-    char in_normal_game;         /* Bool indicating if other obs are set. */
-    short *glyphs;               /* Size ROWNO * (COLNO - 1) */
-    unsigned char *chars;        /* Size ROWNO * (COLNO - 1) */
-    unsigned char *colors;       /* Size ROWNO * (COLNO - 1) */
-    unsigned char *specials;     /* Size ROWNO * (COLNO - 1) */
-    unsigned char *message;      /* Size 256 */
-    long *blstats;               /* NLE_BLSTATS_SIZE */
-    int *program_state;          /* NLE_PROGRAM_STATE_SIZE */
-    int *internal;               /* NLE_INTERNAL_SIZE */
-    short *inv_glyphs;           /* NLE_INVENTORY_SIZE */
+    char in_normal_game;     /* Bool indicating if other obs are set. */
+    short *glyphs;           /* Size ROWNO * (COLNO - 1) */
+    unsigned char *chars;    /* Size ROWNO * (COLNO - 1) */
+    unsigned char *colors;   /* Size ROWNO * (COLNO - 1) */
+    unsigned char *specials; /* Size ROWNO * (COLNO - 1) */
+    unsigned char *message;  /* Size 256 */
+    long *blstats;           /* NLE_BLSTATS_SIZE */
+    int *program_state;      /* NLE_PROGRAM_STATE_SIZE */
+    int *internal;           /* NLE_INTERNAL_SIZE */
+    short *inv_glyphs;       /* NLE_INVENTORY_SIZE */
+    unsigned char
+        *inv_strs; /* NLE_INVENTORY_SIZE * NLE_INVENTORY_STR_LENGTH */
     unsigned char *inv_letters;  /* NLE_INVENTORY_SIZE */
     unsigned char *inv_oclasses; /* NLE_INVENTORY_SIZE */
 } nle_obs;

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -17,7 +17,11 @@ BLSTATS_SHAPE = (_pynethack.nethack.NLE_BLSTATS_SIZE,)
 MESSAGE_SHAPE = (256,)
 PROGRAM_STATE_SHAPE = (_pynethack.nethack.NLE_PROGRAM_STATE_SIZE,)
 INTERNAL_SHAPE = (_pynethack.nethack.NLE_INTERNAL_SIZE,)
-INV_GLYPHS_SHAPE = (_pynethack.nethack.NLE_INVENTORY_SIZE,)
+INV_SIZE = (_pynethack.nethack.NLE_INVENTORY_SIZE,)
+INV_STRS_SHAPE = (
+    _pynethack.nethack.NLE_INVENTORY_SIZE,
+    _pynethack.nethack.NLE_INVENTORY_STR_LENGTH,
+)
 
 OBSERVATION_DESC = {
     "glyphs": dict(shape=DUNGEON_SHAPE, dtype=np.int16),
@@ -28,9 +32,10 @@ OBSERVATION_DESC = {
     "message": dict(shape=MESSAGE_SHAPE, dtype=np.uint8),
     "program_state": dict(shape=PROGRAM_STATE_SHAPE, dtype=np.int32),
     "internal": dict(shape=INTERNAL_SHAPE, dtype=np.int32),
-    "inv_glyphs": dict(shape=INV_GLYPHS_SHAPE, dtype=np.int16),
-    "inv_letters": dict(shape=INV_GLYPHS_SHAPE, dtype=np.uint8),
-    "inv_oclasses": dict(shape=INV_GLYPHS_SHAPE, dtype=np.uint8),
+    "inv_glyphs": dict(shape=INV_SIZE, dtype=np.int16),
+    "inv_letters": dict(shape=INV_SIZE, dtype=np.uint8),
+    "inv_oclasses": dict(shape=INV_SIZE, dtype=np.uint8),
+    "inv_strs": dict(shape=INV_STRS_SHAPE, dtype=np.uint8),
 }
 
 

--- a/nle/scripts/test_raw_nethack.py
+++ b/nle/scripts/test_raw_nethack.py
@@ -5,6 +5,8 @@ import timeit
 import random
 import sys
 
+import numpy as np
+
 from nle import nethack
 
 
@@ -45,9 +47,7 @@ def main():
         89,
     ]
 
-    nle = nethack.Nethack(
-        observation_keys=("chars", "blstats", "message", "inv_letters")
-    )
+    nle = nethack.Nethack(observation_keys=("chars", "blstats", "message", "inv_strs"))
     nle.reset()
 
     nle.step(ord("y"))
@@ -85,18 +85,21 @@ def main():
 
     for i in range(SELF_PLAY_EPISODES):
         print("Starting self-play episode", i)
-        chars, blstats, message, inv_letters = nle.reset()
+        chars, blstats, message, inv_strs = nle.reset()
         done = False
         while not done:
             message = bytes(message)
             print(message)
-            print(inv_letters)
+            for line in inv_strs:
+                if np.all(line == 0):
+                    break
+                print(line.tobytes().decode("utf-8"))
             for line in chars:
                 print(line.tobytes().decode("utf-8"))
             print(blstats)
             try:
                 with no_echo():
-                    (chars, blstats, message, inv_letters), done = nle.step(
+                    (chars, blstats, message, inv_strs), done = nle.step(
                         ord(sys.stdin.read(1))
                     )
             except KeyboardInterrupt:

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -114,7 +114,7 @@ class Nethack
                 py::object specials, py::object blstats, py::object message,
                 py::object program_state, py::object internal,
                 py::object inv_glyphs, py::object inv_letters,
-                py::object inv_oclasses)
+                py::object inv_oclasses, py::object inv_strs)
     {
         std::vector<ssize_t> dungeon{ ROWNO, COLNO - 1 };
         obs_.glyphs = checked_conversion<int16_t>(std::move(glyphs), dungeon);
@@ -136,6 +136,9 @@ class Nethack
             std::move(inv_letters), { NLE_INVENTORY_SIZE });
         obs_.inv_oclasses = checked_conversion<uint8_t>(
             std::move(inv_oclasses), { NLE_INVENTORY_SIZE });
+        obs_.inv_strs = checked_conversion<uint8_t>(
+            std::move(inv_strs),
+            { NLE_INVENTORY_SIZE, NLE_INVENTORY_STR_LENGTH });
     }
 
     void
@@ -230,13 +233,14 @@ PYBIND11_MODULE(_pynethack, m)
              py::arg("inv_glyphs") = py::none(),
              py::arg("inv_letters") = py::none(),
              py::arg("inv_oclasses") = py::none(),
+             py::arg("inv_strs") = py::none(),
 
              py::keep_alive<1, 2>(), py::keep_alive<1, 3>(),
              py::keep_alive<1, 4>(), py::keep_alive<1, 5>(),
              py::keep_alive<1, 6>(), py::keep_alive<1, 7>(),
              py::keep_alive<1, 8>(), py::keep_alive<1, 9>(),
              py::keep_alive<1, 10>(), py::keep_alive<1, 11>(),
-             py::keep_alive<1, 12>())
+             py::keep_alive<1, 12>(), py::keep_alive<1, 13>())
         .def("close", &Nethack::close)
         .def("set_initial_seeds", &Nethack::set_initial_seeds)
         .def("set_seeds", &Nethack::set_seeds)
@@ -251,6 +255,7 @@ PYBIND11_MODULE(_pynethack, m)
     mn.attr("NLE_PROGRAM_STATE_SIZE") = py::int_(NLE_PROGRAM_STATE_SIZE);
     mn.attr("NLE_INTERNAL_SIZE") = py::int_(NLE_INTERNAL_SIZE);
     mn.attr("NLE_INVENTORY_SIZE") = py::int_(NLE_INVENTORY_SIZE);
+    mn.attr("NLE_INVENTORY_STR_LENGTH") = py::int_(NLE_INVENTORY_STR_LENGTH);
 
     /* NetHack constants specific constants. */
     mn.attr("NHW_MESSAGE") = py::int_(NHW_MESSAGE);

--- a/win/rl/winrl.cc
+++ b/win/rl/winrl.cc
@@ -369,6 +369,21 @@ NetHackRL::fill_obs(nle_obs *obs)
             obs->inv_glyphs[i] = NO_GLYPH;
         }
     }
+    if (obs->inv_strs) {
+        int i = 0;
+        for (const rl_inventory_item &item : inventory_) {
+            int j = 0;
+            for (int size = item.str.size(); j < size; ++j) {
+                obs->inv_strs[i++] = item.str[j];
+            }
+            for (; j < NLE_INVENTORY_STR_LENGTH; ++j) {
+                obs->inv_strs[i++] = 0;
+            }
+        }
+        for (; i < NLE_INVENTORY_SIZE * NLE_INVENTORY_STR_LENGTH; ++i) {
+            obs->inv_strs[i] = 0;
+        }
+    }
     if (obs->inv_letters) {
         int i = 0;
         for (const rl_inventory_item &item : inventory_) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77 Bump version to 0.5.1.
* #76 Update lint_python workflow to print diff when black failed.
* #75 Add inv_* observations to base.py.
* #74 Handle keep_alive logic explicitly.
* **#73 Add inv_strs observation.**
* #72 Use update_inventory for inventory observations.
* #71 Add inv_letters and inv_oclasses observations.
* #70 Re-add inventory: Add inv_glyphs observation.

