### PR TITLE
Handle keep_alive logic explicitly.

### DIFF
--- a/include/nleobs.h
+++ b/include/nleobs.h
@@ -2,6 +2,7 @@
 #ifndef NLEOBS_H
 #define NLEOBS_H
 
+#define NLE_MESSAGE_SIZE 256
 #define NLE_BLSTATS_SIZE 25
 #define NLE_PROGRAM_STATE_SIZE 6
 #define NLE_INTERNAL_SIZE 7
@@ -16,7 +17,7 @@ typedef struct nle_observation {
     unsigned char *chars;    /* Size ROWNO * (COLNO - 1) */
     unsigned char *colors;   /* Size ROWNO * (COLNO - 1) */
     unsigned char *specials; /* Size ROWNO * (COLNO - 1) */
-    unsigned char *message;  /* Size 256 */
+    unsigned char *message;  /* Size NLE_MESSAGE_SIZE */
     long *blstats;           /* NLE_BLSTATS_SIZE */
     int *program_state;      /* NLE_PROGRAM_STATE_SIZE */
     int *internal;           /* NLE_INTERNAL_SIZE */

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -14,7 +14,7 @@ DLPATH = os.path.join(os.path.dirname(_pynethack.__file__), "libnethack.so")
 # TODO: Consider getting this from C++.
 DUNGEON_SHAPE = (21, 79)
 BLSTATS_SHAPE = (_pynethack.nethack.NLE_BLSTATS_SIZE,)
-MESSAGE_SHAPE = (256,)
+MESSAGE_SHAPE = (_pynethack.nethack.NLE_MESSAGE_SIZE,)
 PROGRAM_STATE_SHAPE = (_pynethack.nethack.NLE_PROGRAM_STATE_SIZE,)
 INTERNAL_SHAPE = (_pynethack.nethack.NLE_INTERNAL_SIZE,)
 INV_SIZE = (_pynethack.nethack.NLE_INVENTORY_SIZE,)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77 Bump version to 0.5.1.
* #76 Update lint_python workflow to print diff when black failed.
* #75 Add inv_* observations to base.py.
* **#74 Handle keep_alive logic explicitly.**
* #73 Add inv_strs observation.
* #72 Use update_inventory for inventory observations.
* #71 Add inv_letters and inv_oclasses observations.
* #70 Re-add inventory: Add inv_glyphs observation.

