### PR TITLE
Add inv_* observations to base.py.

### DIFF
--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -106,6 +106,10 @@ class NLE(gym.Env):
             "specials",
             "blstats",
             "message",
+            "inv_glyphs",
+            "inv_strs",
+            "inv_letters",
+            "inv_oclasses",
         ),
         actions=None,
         options=None,
@@ -216,28 +220,40 @@ class NLE(gym.Env):
 
         space_dict = {
             "glyphs": gym.spaces.Box(
-                low=0, high=nethack.MAX_GLYPH, shape=DUNGEON_SHAPE, dtype=np.int16
+                low=0, high=nethack.MAX_GLYPH, **nethack.OBSERVATION_DESC["glyphs"]
             ),
             "chars": gym.spaces.Box(
-                low=0, high=255, shape=DUNGEON_SHAPE, dtype=np.uint8
+                low=0, high=255, **nethack.OBSERVATION_DESC["chars"]
             ),
             "colors": gym.spaces.Box(
-                low=0, high=15, shape=DUNGEON_SHAPE, dtype=np.uint8
+                low=0, high=15, **nethack.OBSERVATION_DESC["colors"]
             ),
             "specials": gym.spaces.Box(
-                low=0, high=255, shape=DUNGEON_SHAPE, dtype=np.uint8
+                low=0, high=255, **nethack.OBSERVATION_DESC["specials"]
             ),
             "blstats": gym.spaces.Box(
                 low=np.iinfo(np.int32).min,
                 high=np.iinfo(np.int32).max,
-                shape=nethack.BLSTATS_SHAPE,
-                dtype=np.int32,
+                **nethack.OBSERVATION_DESC["blstats"],
             ),
             "message": gym.spaces.Box(
                 low=np.iinfo(np.uint8).min,
                 high=np.iinfo(np.uint8).max,
-                shape=nethack.MESSAGE_SHAPE,
-                dtype=np.uint8,
+                **nethack.OBSERVATION_DESC["message"],
+            ),
+            "inv_glyphs": gym.spaces.Box(
+                low=0, high=nethack.MAX_GLYPH, **nethack.OBSERVATION_DESC["inv_glyphs"],
+            ),
+            "inv_strs": gym.spaces.Box(
+                low=0, high=128, **nethack.OBSERVATION_DESC["inv_strs"],
+            ),
+            "inv_letters": gym.spaces.Box(
+                low=0, high=128, **nethack.OBSERVATION_DESC["inv_letters"],
+            ),
+            "inv_oclasses": gym.spaces.Box(
+                low=0,
+                high=nethack.MAXOCLASSES,
+                **nethack.OBSERVATION_DESC["inv_oclasses"],
             ),
         }
 
@@ -438,6 +454,15 @@ class NLE(gym.Env):
             message_index = self._observation_keys.index("message")
             message = bytes(self.last_observation[message_index])
             print(message[: message.index(b"\0")])
+            try:
+                inv_strs_index = self._observation_keys.index("inv_strs")
+                inv_strs = self.last_observation[inv_strs_index]
+                for line in inv_strs:
+                    if np.all(line == 0):
+                        break
+                    print(line.tobytes().decode("utf-8"))
+            except ValueError:  # inv_strs not used.
+                pass
             colors_index = self._observation_keys.index("colors")
             chars = self.last_observation[chars_index]
             colors = self.last_observation[colors_index]

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -242,13 +242,13 @@ class NLE(gym.Env):
                 **nethack.OBSERVATION_DESC["message"],
             ),
             "inv_glyphs": gym.spaces.Box(
-                low=0, high=nethack.MAX_GLYPH, **nethack.OBSERVATION_DESC["inv_glyphs"],
+                low=0, high=nethack.MAX_GLYPH, **nethack.OBSERVATION_DESC["inv_glyphs"]
             ),
             "inv_strs": gym.spaces.Box(
-                low=0, high=128, **nethack.OBSERVATION_DESC["inv_strs"],
+                low=0, high=128, **nethack.OBSERVATION_DESC["inv_strs"]
             ),
             "inv_letters": gym.spaces.Box(
-                low=0, high=128, **nethack.OBSERVATION_DESC["inv_letters"],
+                low=0, high=128, **nethack.OBSERVATION_DESC["inv_letters"]
             ),
             "inv_oclasses": gym.spaces.Box(
                 low=0,

--- a/nle/nethack/__init__.py
+++ b/nle/nethack/__init__.py
@@ -9,4 +9,5 @@ from nle.nethack.nethack import (
     MESSAGE_SHAPE,
     PROGRAM_STATE_SHAPE,
     INTERNAL_SHAPE,
+    OBSERVATION_DESC,
 )

--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -119,6 +119,37 @@ class TestGymEnv:
             assert "playmode:debug" not in env.env._options
 
 
+@pytest.mark.parametrize("env_name", [e for e in get_nethack_env_ids() if "Score" in e])
+class TestBasicGymEnv:
+    def test_inventory(self, env_name):
+        env = gym.make(
+            env_name,
+            observation_keys=(
+                "chars",
+                "inv_glyphs",
+                "inv_strs",
+                "inv_letters",
+                "inv_oclasses",
+            ),
+        )
+        obs = env.reset()
+
+        found = dict(spellbook=0, apple=0)
+        for line in obs["inv_strs"]:
+            if np.all(line == 0):
+                break
+            for key in found:
+                if key in line.tobytes().decode("utf-8"):
+                    found[key] += 1
+
+        for key, count in found.items():
+            assert key == key and count > 0
+
+        assert "inv_strs" in obs
+        assert obs["inv_letters"][0] == ord("a")
+        assert obs["inv_oclasses"][0] == nethack.ARMOR_CLASS
+
+
 @pytest.mark.parametrize("env_name", get_nethack_env_ids())
 @pytest.mark.parametrize("rollout_len", [500])
 class TestGymEnvRollout:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77 Bump version to 0.5.1.
* #76 Update lint_python workflow to print diff when black failed.
* **#75 Add inv_* observations to base.py.**
* #74 Handle keep_alive logic explicitly.
* #73 Add inv_strs observation.
* #72 Use update_inventory for inventory observations.
* #71 Add inv_letters and inv_oclasses observations.
* #70 Re-add inventory: Add inv_glyphs observation.

We are now using a flat instead of a nested version for simplicity.