### PR TITLE
Update lint_python workflow to print diff when black failed.

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install python linting deps
       run: "pip install -q black flake8 flake8-bugbear"
     - name: Run black
-      run: "black --check ."
+      run: "black --check --diff ."
     - name: Run flake8
       run: "flake8"
 ...


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77 Bump version to 0.5.1.
* **#76 Update lint_python workflow to print diff when black failed.**
* #75 Add inv_* observations to base.py.
* #74 Handle keep_alive logic explicitly.
* #73 Add inv_strs observation.
* #72 Use update_inventory for inventory observations.
* #71 Add inv_letters and inv_oclasses observations.
* #70 Re-add inventory: Add inv_glyphs observation.

