### PR TITLE
Install the nethack util binaries and their documentation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(PYTHON_SRC_PARENT
     CACHE STRING "Directory containing the nle package files")
 
 set(HACKDIR
-    "$ENV{HOME}/nethackdir"
+    "$ENV{HOME}/nethackdir.nle"
     CACHE STRING "Configuration files for nethack")
 
 message(STATUS "HACKDIR set to: ${HACKDIR}")
@@ -59,6 +59,7 @@ set(NLE_SRC ${nle_SOURCE_DIR}/src)
 set(NLE_INC ${nle_SOURCE_DIR}/include)
 set(NLE_DAT ${nle_SOURCE_DIR}/dat)
 set(NLE_UTIL ${nle_SOURCE_DIR}/util)
+set(NLE_DOC ${nle_SOURCE_DIR}/doc)
 
 set(NLE_SRC_GEN ${nle_BINARY_DIR}/src)
 set(NLE_INC_GEN ${nle_BINARY_DIR}/include)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include version.txt
 
 include CMakeLists.txt
+recursive-include doc *
 recursive-include dat *
 recursive-include DEVEL *
 recursive-include include *
@@ -16,4 +17,3 @@ exclude nle/dashboard
 exclude nle/scripts/nh-clean-install.sh
 exclude nle/scripts/run-clang-format.py
 exclude nle/scripts/line-changed.sh
-

--- a/dat/CMakeLists.txt
+++ b/dat/CMakeLists.txt
@@ -50,23 +50,29 @@ set(DATDLB
 
 file(MAKE_DIRECTORY ${NLE_DAT_GEN})
 
-foreach(
-  filename
-  ${DATHELP}
-  ${SPECIAL_LEVELS}
-  ${QUEST_LEVELS}
-  bogusmon.txt
-  data.base
-  dungeon.def
-  engrave.txt
-  epitaph.txt
-  oracles.txt
-  quest.txt
-  rumors.fal
-  rumors.tru
-  tribute)
+# Inputs to makedef and lev_comp (and transitive inputs to dgn_comp and dlb).
+set(ALL_DAT_NOTGEN
+    ${DATHELP}
+    ${SPECIAL_LEVELS}
+    ${QUEST_LEVELS}
+    bogusmon.txt
+    data.base
+    dungeon.def
+    engrave.txt
+    epitaph.txt
+    oracles.txt
+    quest.txt
+    rumors.fal
+    rumors.tru
+    tribute)
+
+# makedef and friends like having their inputs in the same directory.
+foreach(filename ${ALL_DAT_NOTGEN})
   configure_file(${NLE_DAT}/${filename} ${filename} COPYONLY)
 endforeach(filename)
+
+# Dat files that are not inputs to any tools.
+set(ALL_DAT_NOTGEN ${ALL_DAT_NOTGEN} license symbols)
 
 # TODO(NN): try to glob .lev automatically
 #
@@ -199,20 +205,6 @@ set(LEVS_GEN
     wizard2.lev
     wizard3.lev)
 
-# NOTE: This is missing *.lev, which needs the special lev_comp below.
-set(NLE_DAT_OUTPUT
-    bogusmon
-    epitaph
-    engrave
-    data
-    rumors
-    quest.dat
-    oracles
-    options
-    dungeon
-    dungeon.pdf
-    nhdat)
-
 add_custom_command(
   DEPENDS makedefs bogusmon.txt engrave.txt epitaph.txt
   OUTPUT bogusmon epitaph engrave
@@ -270,10 +262,8 @@ add_custom_command(
 set(ALL_DAT_GEN nhdat perm record logfile xlogfile sysconf)
 list(TRANSFORM ALL_DAT_GEN PREPEND ${NLE_DAT_GEN}/)
 
-set(ALL_DAT_NOTGEN license symbols)
-
 add_custom_target(dat ALL DEPENDS ${ALL_DAT_GEN} ${ALL_DAT_NOTGEN})
 
 install(FILES ${ALL_DAT_GEN} DESTINATION ${INSTDIR})
-install(FILES ${ALL_DAT_NOTGEN} DESTINATION ${INSTDIR})
+install(FILES ${ALL_DAT_NOTGEN} DESTINATION ${INSTDIR}/dat)
 install(DIRECTORY DESTINATION ${INSTDIR}/save)

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -84,20 +84,23 @@ class Nethack:
         options=None,
         copy=False,
         wizard=False,
+        hackdir=HACKDIR,
     ):
         self._copy = copy
 
-        if not os.path.exists(HACKDIR) or not os.path.exists(
-            os.path.join(HACKDIR, "sysconf")
+        if not os.path.exists(hackdir) or not os.path.exists(
+            os.path.join(hackdir, "sysconf")
         ):
-            raise FileNotFoundError("Couldn't find NetHack installation.")
+            raise FileNotFoundError(
+                "Couldn't find NetHack installation at '%s'." % hackdir
+            )
 
         # Create a HACKDIR for us.
         self._vardir = tempfile.mkdtemp(prefix="nle")
 
         # Symlink a few files.
         for fn in ["nhdat", "sysconf"]:
-            os.symlink(os.path.join(HACKDIR, fn), os.path.join(self._vardir, fn))
+            os.symlink(os.path.join(hackdir, fn), os.path.join(self._vardir, fn))
         # Touch a few files.
         for fn in ["perm", "logfile", "xlogfile"]:
             os.close(os.open(os.path.join(self._vardir, fn), os.O_CREAT))

--- a/nle/scripts/patch_nhdat.sh
+++ b/nle/scripts/patch_nhdat.sh
@@ -1,0 +1,55 @@
+set -euo pipefail
+
+ORIGDIR=$(pwd)
+
+HACKDIR=$(python -c 'import pkg_resources; print(pkg_resources.resource_filename("nle", "nethackdir"), end="")')
+
+TMPDIR=$(mktemp -d)
+
+echo $TMPDIR
+
+mkdir $TMPDIR/dat
+cd $TMPDIR/dat
+cp $HACKDIR/dat/dungeon.def .
+patch --ignore-whitespace <<'EOF'
+--- dungeon.def    2019-03-01 15:21:08.000000000 +0100
++++ dungeon.def    2020-09-23 19:17:51.000000000 +0200
+@@ -15,6 +15,7 @@
+ #
+
+ DUNGEON:       "The Dungeons of Doom" "D" (25, 5)
++LEVEL:         "mylevel" "none" @ (1,1)
+ ALIGNMENT:     unaligned
+ BRANCH:                "The Gnomish Mines" @ (2, 3)
+ LEVEL:         "rogue" "R" @ (15, 4)
+
+EOF
+$HACKDIR/makedefs -e  # Looks for ../dat/dungeon.def.
+$HACKDIR/dgn_comp dungeon.pdf
+
+cp $HACKDIR/dat/oracle.des mylevel.des
+patch --ignore-whitespace <<'EOF'
+--- mylevel.des    2019-03-01 15:21:08.000000000 +0100
++++ mylevel.des    2020-09-23 19:01:56.000000000 +0200
+@@ -5,7 +5,7 @@
+ # Oracle level
+ #
+
+-LEVEL: "oracle"
++LEVEL: "mylevel"
+
+ ROOM: "ordinary" , lit, (3,3), (center,center), (11,9) {
+   OBJECT:('`',"statue"),(0,0),montype:'C',1
+EOF
+$HACKDIR/lev_comp mylevel.des
+
+mkdir $TMPDIR/contents
+cd $TMPDIR/contents
+$HACKDIR/dlb xf $HACKDIR/nhdat
+cp -f ../dat/dungeon ../dat/mylevel.lev .
+$HACKDIR/dlb cf nhdat *
+cp nhdat $ORIGDIR
+
+cd $ORIGDIR
+
+rm -rf $TMPDIR

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -85,4 +85,13 @@ add_custom_target(util DEPENDS ${MAKEDEFS_HEADERS} recover)
 add_dependencies(lev_comp util)
 add_dependencies(dgn_comp util)
 
-install(TARGETS recover DESTINATION ${INSTDIR})
+set(MAN_PAGES ${NLE_DOC}/makedefs.6 ${NLE_DOC}/dgn_comp.6 ${NLE_DOC}/lev_comp.6
+              ${NLE_DOC}/dlb.6 ${NLE_DOC}/recover.6 ${NLE_DOC}/nethack.6)
+
+set(TXT_DOCS
+    ${NLE_DOC}/makedefs.txt ${NLE_DOC}/dgn_comp.txt ${NLE_DOC}/lev_comp.txt
+    ${NLE_DOC}/dlb.txt ${NLE_DOC}/recover.txt ${NLE_DOC}/nethack.txt)
+
+install(TARGETS makedefs dgn_comp lev_comp dlb recover DESTINATION ${INSTDIR})
+install(FILES ${MAN_PAGES} DESTINATION ${INSTDIR}/man)
+install(FILES ${TXT_DOCS} DESTINATION ${INSTDIR}/doc)


### PR DESCRIPTION
Using those, we can define our own custom levels, e.g.

1. Use the tar-like tool `dlb` to extract `nhdat`.
2. Add a `mylevel.des` file as per `5. Creating a new level` in
   https://nethackwiki.com/wiki/Beginner%27s_guide_to_NetHack_sources
  (the .des files are part of the NLE installation, but not in `nhdat` as they are sources).
3. Compile that file using `lev_comp`, producing `mylevel.lev`.
4. Add the new level to `dungeon.def` (also part of the NLE installation).
5. Run `makedefs -e` and `dgn_comp dungeon.pdf` to produce `dungeon`.
6. Re-assemble the new set of files using `dlb` which includes `dungeon` and `mylevel.des`.

## Example

From patch_nhdat.sh in this commit:

```sh
HACKDIR=$(python -c 'import pkg_resources; print(pkg_resources.resource_filename("nle", "nethackdir"), end="")')

TMPDIR=/tmp/patch_nhdat
mkdir $TMPDIR

mkdir $TMPDIR/dat
cd $TMPDIR/dat
cp $HACKDIR/dat/dungeon.def .
patch --ignore-whitespace <<'EOF'
--- dungeon.def      2019-03-01 15:21:08.000000000 +0100
+++ dungeon.def 2020-09-23 19:17:51.000000000 +0200
@@ -15,6 +15,7 @@
 #

 DUNGEON:       "The Dungeons of Doom" "D" (25, 5)
+LEVEL:         "mylevel" "none" @ (1,1)
 ALIGNMENT:     unaligned
 BRANCH:                "The Gnomish Mines" @ (2, 3)
 LEVEL:         "rogue" "R" @ (15, 4)

EOF
$HACKDIR/makedefs -e  # Looks for ../dat/dungeon.def.
$HACKDIR/dgn_comp dungeon.pdf

cp $HACKDIR/dat/oracle.des mylevel.des
patch --ignore-whitespace <<'EOF'
--- mylevel.des       2019-03-01 15:21:08.000000000 +0100
+++ mylevel.des     2020-09-23 19:01:56.000000000 +0200
@@ -5,7 +5,7 @@
 # Oracle level
 #

-LEVEL: "oracle"
+LEVEL: "mylevel"

 ROOM: "ordinary" , lit, (3,3), (center,center), (11,9) {
   OBJECT:('`',"statue"),(0,0),montype:'C',1
EOF
$HACKDIR/lev_comp mylevel.des

mkdir $TMPDIR/contents
cd $TMPDIR/contents
$HACKDIR/dlb xf $HACKDIR/nhdat
cp -f ../dat/dungeon ../dat/mylevel.lev .
$HACKDIR/dlb cf nhdat *

# Now copy nhdat somewhere to use it.
```