### PR TITLE
Add objclass and objdescr as Python classes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ add_dependencies(rlmain util) # For pm.h.
 # pybind11 python library.
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/pybind11)
 pybind11_add_module(_pynethack win/rl/pynethack.cc src/monst.c src/decl.c
-                    src/drawing.c)
+                    src/drawing.c src/objects.c)
 target_link_libraries(_pynethack PUBLIC nethackdl)
 set_target_properties(_pynethack PROPERTIES CXX_STANDARD 14)
 target_include_directories(_pynethack PUBLIC ${NLE_INC_GEN})

--- a/nle/tests/test_nethack.py
+++ b/nle/tests/test_nethack.py
@@ -247,6 +247,15 @@ class TestNethackSomeObs:
         assert internal[3] == 1  # xwaitforspace
 
 
+def get_object(name):
+    for index in range(nethack.NUM_OBJECTS):
+        obj = nethack.objclass(index)
+        if nethack.OBJ_NAME(obj) == name:
+            return obj
+    else:
+        raise ValueError("'%s' not found!" % name)
+
+
 class TestNethackFunctionsAndConstants:
     def test_permonst_and_class_sym(self):
         glyph = 155  # Lichen.
@@ -296,3 +305,29 @@ class TestNethackFunctionsAndConstants:
             % nethack.MAXMCLASSES,
         ):
             nethack.class_sym.from_mlet("\x7F")
+
+    def test_objclass(self):
+        obj = nethack.objclass(0)
+        assert nethack.OBJ_NAME(obj) == "strange object"
+
+        food_ration = get_object("food ration")
+        assert food_ration.oc_weight == 20
+
+        elven_dagger = get_object("elven dagger")
+        assert nethack.OBJ_DESCR(elven_dagger) == "runed dagger"
+
+    def test_objdescr(self):
+        od = nethack.objdescr.from_idx(0)
+        assert od.oc_name == "strange object"
+        assert od.oc_descr is None
+
+        elven_dagger = get_object("elven dagger")
+        od = nethack.objdescr.from_idx(elven_dagger.oc_name_idx)
+        assert od.oc_name == "elven dagger"
+        assert od.oc_descr == "runed dagger"
+
+        # Example of how to do this with glyphs.
+        glyph = nethack.GLYPH_OBJ_OFF + elven_dagger.oc_name_idx
+        idx = nethack.glyph_to_obj(glyph)
+        assert idx == elven_dagger.oc_name_idx
+        assert nethack.objdescr.from_idx(idx) is od


### PR DESCRIPTION
This is a bit more complicated than permonst as the user can
"name" and "discover" an object and hence change it. This here does
not interact with any real running NetHack, so these fields won't
change and/or have any real information.