### PR TITLE
Update README, docs, GitHub workflows, Dockerfiles.

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -27,6 +27,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Ensure latest pip & wheel
       run: "python -m pip install -q --upgrade pip wheel"
+    - name: Install dependencies
+      run: |
+        brew install cmake
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -56,6 +59,9 @@ jobs:
         python-version: 3.8
     - name: Ensure latest pip & wheel
       run: "python -m pip install -q --upgrade pip wheel"
+    - name: Install dependencies
+      run: |
+        brew install cmake
     - uses: actions/checkout@v2
       with:
         submodules: true

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -27,11 +27,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Ensure latest pip & wheel
       run: "python -m pip install -q --upgrade pip wheel"
-    - name: Install dependencies
-      run: |
-        brew install zeromq flatbuffers cmake
-        sudo wget https://raw.githubusercontent.com/zeromq/cppzmq/v4.3.0/zmq.hpp -P \
-          /usr/local/include
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -61,11 +56,6 @@ jobs:
         python-version: 3.8
     - name: Ensure latest pip & wheel
       run: "python -m pip install -q --upgrade pip wheel"
-    - name: Install deps
-      run: |
-        brew install zeromq flatbuffers cmake
-        sudo wget https://raw.githubusercontent.com/zeromq/cppzmq/v4.3.0/zmq.hpp -P \
-          /usr/local/include
     - uses: actions/checkout@v2
       with:
         submodules: true

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -20,6 +20,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Ensure latest pip & wheel
       run: "python -m pip install -q --upgrade pip wheel"
+    - name: Install dependencies
+      run: |
+        brew install cmake
     - name: Clone repo
       uses: actions/checkout@v2
     - name: Install nle via pip

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -20,14 +20,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Ensure latest pip & wheel
       run: "python -m pip install -q --upgrade pip wheel"
-    - name: Install dependencies
-      run: |
-        brew install zeromq flatbuffers
-        sudo wget https://raw.githubusercontent.com/zeromq/cppzmq/v4.3.0/zmq.hpp -P \
-          /usr/local/include
     - name: Clone repo
       uses: actions/checkout@v2
-    - name: Install from repo in test mode
+    - name: Install nle via pip
       run: "pip install nle"
     - name: Check nethack is installed
-      run: "type -p nethack"
+      run: "python -c 'import nle; import gym; gym.make(\"NetHack-v0\")'"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ On **MacOS**, one can use `Homebrew` as follows:
 $ brew install ncurses cmake
 ```
 
-On a plain **Ubuntu 18.04** distribution, `cmake` other dependencies
+On a plain **Ubuntu 18.04** distribution, `cmake` and other dependencies
 can be installed by doing:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ NLE requires `python>=3.7`, `cmake>=3.14` and some NetHack dependencies
 (e.g. `libncurses`) to be installed and available both when building the
 package, and at runtime.
 
+On **MacOS**, one can use `Homebrew` as follows:
+
+``` bash
+$ brew install ncurses cmake
+```
 
 On a plain **Ubuntu 18.04** distribution, `cmake` other dependencies
 can be installed by doing:

--- a/README.md
+++ b/README.md
@@ -31,27 +31,18 @@ with other gym / RL environments.
 
 ## Installation
 
-NLE requires `python>=3.7`, `cmake>=3.12`, `libzmq`, `flatbuffers`, and some
-NetHack dependencies (e.g. `libncurses`) to be installed and available both when
-building the package, and at runtime.
+NLE requires `python>=3.7`, `cmake>=3.14` and some NetHack dependencies
+(e.g. `libncurses`) to be installed and available both when building the
+package, and at runtime.
 
 
-On **MacOS**, one can use `Homebrew` as follows:
-
-``` bash
-$ brew install ncurses flatbuffers zeromq cmake
-$ sudo wget https://raw.githubusercontent.com/zeromq/cppzmq/v4.3.0/zmq.hpp -P \
-     /usr/local/include
-```
-
-On a plain **Ubuntu 18.04** distribution, `cmake`, `flatbuffers` and other
-dependencies can be installed by doing:
+On a plain **Ubuntu 18.04** distribution, `cmake` other dependencies
+can be installed by doing:
 
 ```bash
-# zmq, python, and most build deps
+# Python and most build deps
 $ sudo apt-get install -y build-essential autoconf libtool pkg-config \
-    python3-dev python3-pip python3-numpy git libncurses5-dev \
-    libzmq3-dev flex bison
+    python3-dev python3-pip python3-numpy git libncurses5-dev flex bison
 
 # recent cmake version
 $ wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
@@ -59,13 +50,6 @@ $ sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 $ sudo apt-get update && apt-get --allow-unauthenticated install -y \
     cmake \
     kitware-archive-keyring
-
-# building flatbuffers
-$ git clone https://github.com/google/flatbuffers.git
-$ cd flatbuffers
-$ cmake -G "Unix Makefiles"
-$ make
-$ sudo make install
 ```
 
 Afterwards it's a matter of setting up your environment. We advise using a conda
@@ -74,7 +58,6 @@ environment for this:
 ```bash
 $ conda create -n nle python=3.8
 $ conda activate nle
-$ conda install cppzmq  # might not be necessary on some systems
 $ pip install nle
 ```
 
@@ -90,7 +73,8 @@ $ pre-commit install
 
 ## Docker
 
-We have provided some docker images. Please see the [relevant README](docker/README.md).
+We have provided some docker images. Please see the [relevant
+README](docker/README.md).
 
 
 ## Trying it out
@@ -138,7 +122,7 @@ $ python -m nle.agent.agent --num_actors 80 --batch_size 32 --unroll_length 80 -
 
 Plot the mean return over the last 100 episodes:
 ```bash
-$ python -m nle.scripts.plot 
+$ python -m nle.scripts.plot
 ```
 ```
                               averaged episode return

--- a/doc/nle/source/getting_started.rst
+++ b/doc/nle/source/getting_started.rst
@@ -8,6 +8,12 @@ NLE requires `python>=3.7`, `cmake>=3.14` and some NetHack dependencies
 (e.g. `libncurses`) to be installed and available both when building the
 package, and at runtime.
 
+On **MacOS**, one can use `Homebrew` as follows:
+
+``` bash
+$ brew install ncurses cmake
+```
+
 On a plain **Ubuntu 18.04** distribution, `cmake` other dependencies
 can be installed by doing:
 

--- a/doc/nle/source/getting_started.rst
+++ b/doc/nle/source/getting_started.rst
@@ -14,7 +14,7 @@ On **MacOS**, one can use `Homebrew` as follows:
 $ brew install ncurses cmake
 ```
 
-On a plain **Ubuntu 18.04** distribution, `cmake` other dependencies
+On a plain **Ubuntu 18.04** distribution, `cmake` and other dependencies
 can be installed by doing:
 
 ```bash

--- a/doc/nle/source/getting_started.rst
+++ b/doc/nle/source/getting_started.rst
@@ -4,33 +4,25 @@ Getting Started
 Dependencies
 ************
 
-NLE requires ``python>=3.7``, ``libzmq``, and ``flatbuffers`` to be installed and
-available when building the package.
+NLE requires `python>=3.7`, `cmake>=3.14` and some NetHack dependencies
+(e.g. `libncurses`) to be installed and available both when building the
+package, and at runtime.
 
-On **MacOS** you can use brew to install ``libzmq``:
+On a plain **Ubuntu 18.04** distribution, `cmake` other dependencies
+can be installed by doing:
 
-.. code-block:: bash
+```bash
+# Python and most build deps
+$ sudo apt-get install -y build-essential autoconf libtool pkg-config \
+    python3-dev python3-pip python3-numpy git libncurses5-dev flex bison
 
-   $ brew install zeromq
-   $ sudo wget https://raw.githubusercontent.com/zeromq/cppzmq/v4.3.0/zmq.hpp -P \
-       /usr/local/include
-
-
-On **Ubuntu 18.04** instead:
-
-.. code-block:: bash
-
-   $ sudo apt-get install libzmq3-dev
-
-
-For ``flatbuffers`` we instead advise to use conda, as that is the easiest way to
-pull the dependencies:
-
-.. code-block:: bash
-
-   $ conda create -n nledev python=3.7
-   $ conda activate nledev
-   $ conda install flatbuffers
+# recent cmake version
+$ wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+$ sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+$ sudo apt-get update && apt-get --allow-unauthenticated install -y \
+    cmake \
+    kitware-archive-keyring
+```
 
 
 Installation

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,8 +24,7 @@ RUN apt-get update && apt-get install -y \
     clang \
     bison \
     flex \
-    libncurses-dev \
-    libzmq3-dev
+    libncurses-dev
 
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
 
@@ -33,18 +32,6 @@ RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 RUN apt-get update && apt-get --allow-unauthenticated install -yq \
     cmake \
     kitware-archive-keyring
-
-WORKDIR /opt/flatbuffers
-
-RUN curl -fSL "https://github.com/google/flatbuffers/archive/v1.12.0.tar.gz" -o flatbuffers.tar.gz \
-    && tar xzf flatbuffers.tar.gz \
-    && cd flatbuffers-* \
-    && cmake \
-       -G "Unix Makefiles" \
-       -DCMAKE_BUILD_TYPE=Release \
-    && make \
-    && make install \
-    && cp src/idl_parser.cpp src/idl_gen_text.cpp /usr/local/include/flatbuffers
 
 WORKDIR /opt/conda_setup
 

--- a/docker/Dockerfile-xenial
+++ b/docker/Dockerfile-xenial
@@ -25,8 +25,7 @@ RUN apt-get update && apt-get install -yq \
     clang \
     bison \
     flex \
-    libncurses-dev \
-    libzmq3-dev
+    libncurses-dev
 
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
     | gpg -dearmor - \
@@ -34,18 +33,6 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
 
 RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main'
 RUN apt-get update && apt-get --allow-unauthenticated install -yq cmake
-
-WORKDIR /opt/flatbuffers
-
-RUN curl -fSL "https://github.com/google/flatbuffers/archive/v1.12.0.tar.gz" -o flatbuffers.tar.gz \
-    && tar xzf flatbuffers.tar.gz \
-    && cd flatbuffers-* \
-    && cmake \
-       -G "Unix Makefiles" \
-       -DCMAKE_BUILD_TYPE=Release \
-    && make \
-    && make install \
-    && cp src/idl_parser.cpp src/idl_gen_text.cpp /usr/local/include/flatbuffers
 
 WORKDIR /opt/conda_setup
 

--- a/sys/unix/Makefile.src
+++ b/sys/unix/Makefile.src
@@ -1,7 +1,6 @@
 #	NetHack Makefile.
 # NetHack 3.6  Makefile.src    $NHDT-Date: 1550876124 2019/02/22 22:55:24 $  $NHDT-Branch: NetHack-3.6.2-beta01 $:$NHDT-Revision: 1.70 $
 # Copyright (c) 2018 by Pasi Kallinen
-# Copyright (c) Facebook, Inc. and its affiliates.
 # NetHack may be freely redistributed.  See license for details.
 
 # Root of source tree:
@@ -172,15 +171,15 @@ GNOMEINC=-I/usr/lib/glib/include -I/usr/lib/gnome-libs/include -I../win/gnome
 # CFLAGS = -g -I../include
 
 #CFLAGS = -O -I../include
-#LFLAGS =
+#LFLAGS = 
 
 # The Qt and Be window systems are written in C++, while the rest of
 # NetHack is standard C.  If using Qt, uncomment the LINK line here to get
 # the C++ libraries linked in.
-#CXXFLAGS = $(CFLAGS) -I. -I$(QTDIR)/include
+CXXFLAGS = $(CFLAGS) -I. -I$(QTDIR)/include
 CXX ?= g++
 MOC ?= moc
-LINK=g++
+#LINK=g++
 #	For cross-compiling, eg. with gcc on Linux (see also CC further up):
 #CXX=arm-linux-g++
 #LINK=arm-linux-gcc
@@ -266,11 +265,6 @@ WINBEOBJ =
 #WINBESRC = ../win/BeOS/winbe.cpp ../win/BeOS/NHWindow.cpp \
 #	../win/BeOS/NHMenuWindow.cpp ../win/BeOS/NHMapWindow.cpp tile.c
 #WINBEOBJ = winbe.o NHWindow.o NHMenuWindow.o NHMapWindow.o tile.o
-
-# Files for a RL port
-WINRLSRC = ../win/rl/winrl.cc
-WINRLOBJ = winrl.o
-
 #
 #
 #WINSRC = $(WINTTYSRC)
@@ -322,11 +316,8 @@ WINGNOMELIB = -lgnomeui -lgnome -lart_lgpl -lgtk -lgdk -lpopt
 # libraries for Gem port
 WINGEMLIB = -le_gem -lgem
 #
-# libraries for BeOS
+# libraries for BeOS 
 WINBELIB = -lbe
-#
-# libraries for RL
-WINRLLIB = -lzmq
 #
 # libraries for curses port
 # link with ncurses
@@ -603,10 +594,6 @@ monst.o:
 objects.o:
 	$(CC) $(CFLAGS) -c objects.c
 	@rm -f $(MAKEDEFS)
-
-# flatc invocation for RL window proc
-../win/rl/rpc_generated.h: ../win/rl/message.fbs
-	flatc -o ../win/rl --cpp --python ../win/rl/message.fbs
 
 # Qt 3 windowport meta-object-compiler output
 qt_kde0.moc: ../include/qt_kde0.h
@@ -983,10 +970,6 @@ qt4xcmd.o: ../win/Qt4/qt4xcmd.cpp $(HACK_H) ../include/func_tab.h \
 qt4yndlg.o: ../win/Qt4/qt4yndlg.cpp $(HACK_H) ../win/Qt4/qt4yndlg.h \
 		qt4yndlg.moc ../win/Qt4/qt4str.h
 	$(CXX) $(CXXFLAGS) -c -o $@ ../win/Qt4/qt4yndlg.cpp
-
-winrl.o : ../win/rl/winrl.cc ../win/rl/rpc_generated.h $(HACK_H)
-	$(CXX) $(CXXFLAGS) -c ../win/rl/winrl.cc
-
 wc_chainin.o: ../win/chain/wc_chainin.c $(HACK_H)
 	$(CC) $(CFLAGS) -c -o $@ ../win/chain/wc_chainin.c
 wc_chainout.o: ../win/chain/wc_chainout.c $(HACK_H)


### PR DESCRIPTION
Remove all mentions of `zmq`/`zeromq` and `flatbuffers` as we no longer depend on those libraries.