### PR TITLE
Fix terminal size at 80x24, write bzip2'ed ttyrecs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
           command: |
             sudo apt-get install software-properties-common
             sudo apt-get update -y
-            sudo apt-get install -y libncurses5 libncurses5-dev flex bison cmake
+            sudo apt-get install -y libncurses5 libncurses5-dev flex bison cmake libbz2-dev
 
   pip-install-nle:
     description: Installs NLE and its dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ target_link_directories(nethack PUBLIC /usr/local/lib)
 
 # On Ubuntu 20.04, libncurses6 seems to cause a SEGFAULT on tgetent?
 find_library(NCURSES_LIB NAMES libncurses.so.5 libncurses ncurses)
-target_link_libraries(nethack PUBLIC m fcontext ${NCURSES_LIB})
+target_link_libraries(nethack PUBLIC m fcontext ${NCURSES_LIB} bz2)
 
 # dlopen wrapper library
 add_library(nethackdl STATIC "sys/unix/nledl.c")

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ can be installed by doing:
 ```bash
 # Python and most build deps
 $ sudo apt-get install -y build-essential autoconf libtool pkg-config \
-    python3-dev python3-pip python3-numpy git libncurses5-dev flex bison
+    python3-dev python3-pip python3-numpy git libncurses5-dev flex bison libbz2-dev
 
 # recent cmake version
 $ wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -

--- a/include/nle.h
+++ b/include/nle.h
@@ -1,6 +1,8 @@
 #ifndef NLE_H
 #define NLE_H
 
+#define NLE_BZ2_TTYRECS
+
 #include <stdio.h>
 
 #include <fcontext/fcontext.h>
@@ -20,6 +22,10 @@ typedef struct nle_globals {
     char outbuf[BUFSIZ];
     char *outbuf_write_ptr;
     char *outbuf_write_end;
+
+#ifdef NLE_BZ2_TTYRECS
+    void *ttyrec_bz2;
+#endif
 
     boolean done;
     nle_obs *observation;

--- a/include/unixconf.h
+++ b/include/unixconf.h
@@ -139,7 +139,7 @@
 #define TIMED_DELAY
 #endif
 
-/* #define AVOID_WIN_IOCTL */ /* ensure USE_WIN_IOCTL remains undefined */
+#define AVOID_WIN_IOCTL /* ensure USE_WIN_IOCTL remains undefined */
 
 /*
  * If you define MAIL, then the player will be notified of new mail

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -201,7 +201,7 @@ class NLE(gym.Env):
 
         if self.savedir:
             self._ttyrec_pattern = os.path.join(
-                self.savedir, "nle.%i.%%i.ttyrec" % os.getpid()
+                self.savedir, "nle.%i.%%i.ttyrec.bz2" % os.getpid()
             )
             ttyrec = self._ttyrec_pattern % 0
         else:

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -80,7 +80,7 @@ class Nethack:
         self,
         observation_keys=OBSERVATION_DESC.keys(),
         playername="Agent-mon-hum-neu-mal",
-        ttyrec="nle.ttyrec",
+        ttyrec="nle.ttyrec.bz2",
         options=None,
         copy=False,
         wizard=False,

--- a/nle/scripts/play.py
+++ b/nle/scripts/play.py
@@ -74,7 +74,7 @@ def play(env, mode, ngames, max_steps, seeds, savedir, no_render, debug):
     if is_raw_env:
         if savedir is not None:
             os.makedirs(savedir, exist_ok=True)
-            ttyrec = os.path.join(savedir, "nle.ttyrec")
+            ttyrec = os.path.join(savedir, "nle.ttyrec.bz2")
         else:
             ttyrec = "/dev/null"
         env = nethack.Nethack(ttyrec=ttyrec)

--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -224,7 +224,7 @@ class TestGymEnvRollout:
             env.close()
 
             assert os.path.exists(
-                os.path.join(savedir, "nle.%i.0.ttyrec" % os.getpid())
+                os.path.join(savedir, "nle.%i.0.ttyrec.bz2" % os.getpid())
             )
 
     def test_rollout_no_archive(self, env_name, rollout_len):

--- a/src/nle.c
+++ b/src/nle.c
@@ -219,6 +219,10 @@ init_random(int FDECL((*fn), (int) ))
 nle_ctx_t *
 nle_start(nle_obs *obs, FILE *ttyrec, nle_seeds_init_t *seed_init)
 {
+    /* Set CO and LI to control ttyrec output size. */
+    CO = 80;
+    LI = 24;
+
     nle_ctx_t *nle = init_nle(ttyrec);
     nle->observation = obs;
     nle_seeds_init = seed_init;


### PR DESCRIPTION
* Setting the terminal size makes sure our ttyrecs will be 80x24, which is both the minimum size and the size of the majority of ttyrecs on alt.org
* Writing bzip2'd ttyrecs should save up to 80% of disk space. Only downside is that we can no longer peek into running ttyrecs this way, which was sometimes useful for debugging. To go back to that mode, we can `#undefine NLE_BZ2_TTYRECS`.