### PR TITLE
Terminal ttyrec stuff

### DIFF
--- a/nle/scripts/read_tty.py
+++ b/nle/scripts/read_tty.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import struct
+import os
 
 
 def ttyframes(f, tty2=True):
@@ -30,6 +31,23 @@ def ttyframes(f, tty2=True):
         yield timestamp, channel, data
 
 
+def getfile(filename):
+    if filename == "-":
+        f = os.fdopen(os.dup(0), "rb")
+        os.dup2(1, 0)
+        return f
+    elif os.path.splitext(filename)[1] in (".bz2", ".bzip2"):
+        import bz2
+
+        return bz2.BZ2File(filename)
+    elif os.path.splitext(filename)[1] in (".gz", ".gzip"):
+        import gzip
+
+        return gzip.GzipFile(filename)
+    else:
+        return open(filename, "rb")
+
+
 if __name__ == "__main__":
     import datetime
     import sys
@@ -38,7 +56,7 @@ if __name__ == "__main__":
         return "\033[%d;3%dm%s\033[0m" % (bool(value & 8), value & ~8, s)
 
     filename = sys.argv[1]
-    with open(filename, "rb") as f:
+    with getfile(filename) as f:
         for timestamp, channel, data in ttyframes(f):
             if channel == 0:
                 data = str(data)[2:-1]  # Strip b' and '

--- a/nle/scripts/read_tty.py
+++ b/nle/scripts/read_tty.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import struct
 import os
+import re
 
 
 def ttyframes(f, tty2=True):
@@ -65,6 +66,15 @@ if __name__ == "__main__":
                 action, *_ = struct.unpack("<B", data)
                 data = action
                 channel = "->"
+
+            data = re.sub(r"\\x1b\[([0-9];?)*.", lambda m: color(m.group(0), 8), data)
+            data = re.sub(
+                r"(\\x1b\(0)(.*?)(\\x1b\(B)",
+                lambda m: (
+                    color(m.group(1), 4) + color(m.group(2), 3) + color(m.group(3), 4)
+                ),
+                data,
+            )
 
             print(
                 "%s %s%s%s%s"

--- a/nle/scripts/ttyrec.py
+++ b/nle/scripts/ttyrec.py
@@ -30,6 +30,12 @@ parser.add_argument("--keep_stderr", action="store_true", help="don't process st
 parser.add_argument(
     "filename", default="out.ttyrec", type=str, nargs="?", help="tty record file"
 )
+parser.add_argument(
+    "-c", "--columns", type=int, help="override number of columns",
+)
+parser.add_argument(
+    "-r", "--rows", type=int, help="override number rows",
+)
 
 
 def write_header(fp, length, channel):
@@ -113,6 +119,13 @@ def main():
 
     winsz = bytearray(8)
     fcntl.ioctl(0, termios.TIOCGWINSZ, winsz)
+
+    ws_row, ws_col, ws_xpixel, ws_ypixel = struct.unpack("HHHH", winsz)
+    if FLAGS.rows is not None:
+        ws_row = FLAGS.rows
+    if FLAGS.columns is not None:
+        ws_col = FLAGS.columns
+    struct.pack_into("HHHH", winsz, 0, ws_row, ws_col, ws_xpixel, ws_ypixel)
 
     fdmaster, fdslave = os.openpty()
     fcntl.ioctl(fdslave, termios.TIOCSWINSZ, winsz)

--- a/nle/scripts/ttyrec.py
+++ b/nle/scripts/ttyrec.py
@@ -30,12 +30,8 @@ parser.add_argument("--keep_stderr", action="store_true", help="don't process st
 parser.add_argument(
     "filename", default="out.ttyrec", type=str, nargs="?", help="tty record file"
 )
-parser.add_argument(
-    "-c", "--columns", type=int, help="override number of columns",
-)
-parser.add_argument(
-    "-r", "--rows", type=int, help="override number rows",
-)
+parser.add_argument("-c", "--columns", type=int, help="override number of columns")
+parser.add_argument("-r", "--rows", type=int, help="override number rows")
 
 
 def write_header(fp, length, channel):


### PR DESCRIPTION
Impression on how the `read_tty.py` output looks now:

![image](https://user-images.githubusercontent.com/69371/97011655-43d7a780-1547-11eb-8424-c50635e9de0c.png)

See https://github.com/deadpixi/libtmt#supported-input-and-escape-sequences and https://en.wikipedia.org/wiki/DEC_Special_Graphics for details on what these things mean.