### PR TITLE
Add text descriptions as an observation for each object on the map.

### DIFF
--- a/include/nleobs.h
+++ b/include/nleobs.h
@@ -8,7 +8,7 @@
 #define NLE_INTERNAL_SIZE 7
 #define NLE_INVENTORY_SIZE 55
 #define NLE_INVENTORY_STR_LENGTH 80
-#define NLE_GLYPH_STR_LENGTH 80
+#define NLE_SCREEN_DESCRIPTION_LENGTH 80
 
 typedef struct nle_observation {
     int action;
@@ -27,7 +27,7 @@ typedef struct nle_observation {
         *inv_strs; /* NLE_INVENTORY_SIZE * NLE_INVENTORY_STR_LENGTH */
     unsigned char *inv_letters;  /* NLE_INVENTORY_SIZE */
     unsigned char *inv_oclasses; /* NLE_INVENTORY_SIZE */
-    unsigned char *glyph_strs;  /* Size ROWNO * (COLNO - 1) * NLE_GLYPH_STR_LENGTH */
+    unsigned char *screen_descriptions;  /* Size ROWNO * (COLNO - 1) * NLE_SCREEN_DESCRIPTION_LENGTH */
 } nle_obs;
 
 typedef struct {

--- a/include/nleobs.h
+++ b/include/nleobs.h
@@ -27,7 +27,7 @@ typedef struct nle_observation {
         *inv_strs; /* NLE_INVENTORY_SIZE * NLE_INVENTORY_STR_LENGTH */
     unsigned char *inv_letters;  /* NLE_INVENTORY_SIZE */
     unsigned char *inv_oclasses; /* NLE_INVENTORY_SIZE */
-    short *glyph_strs;  /* Size ROWNO * (COLNO - 1) * NLE_GLYPH_STR_LENGTH */
+    unsigned char *glyph_strs;  /* Size ROWNO * (COLNO - 1) * NLE_GLYPH_STR_LENGTH */
 } nle_obs;
 
 typedef struct {

--- a/include/nleobs.h
+++ b/include/nleobs.h
@@ -26,6 +26,7 @@ typedef struct nle_observation {
         *inv_strs; /* NLE_INVENTORY_SIZE * NLE_INVENTORY_STR_LENGTH */
     unsigned char *inv_letters;  /* NLE_INVENTORY_SIZE */
     unsigned char *inv_oclasses; /* NLE_INVENTORY_SIZE */
+    short *glyphs2;           /* Size ROWNO * (COLNO - 1) */
 } nle_obs;
 
 typedef struct {

--- a/include/nleobs.h
+++ b/include/nleobs.h
@@ -8,6 +8,7 @@
 #define NLE_INTERNAL_SIZE 7
 #define NLE_INVENTORY_SIZE 55
 #define NLE_INVENTORY_STR_LENGTH 80
+#define NLE_GLYPH_STR_LENGTH 80
 
 typedef struct nle_observation {
     int action;
@@ -26,7 +27,7 @@ typedef struct nle_observation {
         *inv_strs; /* NLE_INVENTORY_SIZE * NLE_INVENTORY_STR_LENGTH */
     unsigned char *inv_letters;  /* NLE_INVENTORY_SIZE */
     unsigned char *inv_oclasses; /* NLE_INVENTORY_SIZE */
-    short *glyphs2;           /* Size ROWNO * (COLNO - 1) */
+    short *glyph_strs;  /* Size ROWNO * (COLNO - 1) * NLE_GLYPH_STR_LENGTH */
 } nle_obs;
 
 typedef struct {

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -106,7 +106,7 @@ class NLE(gym.Env):
             "inv_strs",
             "inv_letters",
             "inv_oclasses",
-            "glyph_strs",
+            "screen_descriptions",
         ),
         actions=None,
         options=None,
@@ -271,8 +271,8 @@ class NLE(gym.Env):
                 high=nethack.MAXOCLASSES,
                 **nethack.OBSERVATION_DESC["inv_oclasses"],
             ),
-            "glyph_strs": gym.spaces.Box(
-                low=0, high=128, **nethack.OBSERVATION_DESC["glyph_strs"]
+            "screen_descriptions": gym.spaces.Box(
+                low=0, high=128, **nethack.OBSERVATION_DESC["screen_descriptions"]
             ),
         }
 

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -106,7 +106,7 @@ class NLE(gym.Env):
             "inv_strs",
             "inv_letters",
             "inv_oclasses",
-            "glyph_strs"
+            "glyph_strs",
         ),
         actions=None,
         options=None,

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -261,10 +261,10 @@ class NLE(gym.Env):
                 **nethack.OBSERVATION_DESC["inv_glyphs"],
             ),
             "inv_strs": gym.spaces.Box(
-                low=0, high=128, **nethack.OBSERVATION_DESC["inv_strs"]
+                low=0, high=127, **nethack.OBSERVATION_DESC["inv_strs"]
             ),
             "inv_letters": gym.spaces.Box(
-                low=0, high=128, **nethack.OBSERVATION_DESC["inv_letters"]
+                low=0, high=127, **nethack.OBSERVATION_DESC["inv_letters"]
             ),
             "inv_oclasses": gym.spaces.Box(
                 low=0,
@@ -272,7 +272,7 @@ class NLE(gym.Env):
                 **nethack.OBSERVATION_DESC["inv_oclasses"],
             ),
             "screen_descriptions": gym.spaces.Box(
-                low=0, high=128, **nethack.OBSERVATION_DESC["screen_descriptions"]
+                low=0, high=127, **nethack.OBSERVATION_DESC["screen_descriptions"]
             ),
         }
 

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -106,6 +106,7 @@ class NLE(gym.Env):
             "inv_strs",
             "inv_letters",
             "inv_oclasses",
+            "glyph_strs"
         ),
         actions=None,
         options=None,
@@ -269,6 +270,9 @@ class NLE(gym.Env):
                 low=0,
                 high=nethack.MAXOCLASSES,
                 **nethack.OBSERVATION_DESC["inv_oclasses"],
+            ),
+            "glyph_strs": gym.spaces.Box(
+                low=0, high=128, **nethack.OBSERVATION_DESC["glyph_strs"]
             ),
         }
 

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -22,7 +22,7 @@ INV_STRS_SHAPE = (
     _pynethack.nethack.NLE_INVENTORY_SIZE,
     _pynethack.nethack.NLE_INVENTORY_STR_LENGTH,
 )
-GLYPH_STRS_SHAPE = DUNGEON_SHAPE# DUNGEON_SHAPE + (_pynethack.nethack.NLE_GLYPH_STR_LENGTH,)
+GLYPH_STRS_SHAPE = DUNGEON_SHAPE + (_pynethack.nethack.NLE_GLYPH_STR_LENGTH,)
 
 OBSERVATION_DESC = {
     "glyphs": dict(shape=DUNGEON_SHAPE, dtype=np.int16),
@@ -37,7 +37,7 @@ OBSERVATION_DESC = {
     "inv_letters": dict(shape=INV_SIZE, dtype=np.uint8),
     "inv_oclasses": dict(shape=INV_SIZE, dtype=np.uint8),
     "inv_strs": dict(shape=INV_STRS_SHAPE, dtype=np.uint8),
-    "glyph_strs": dict(shape=GLYPH_STRS_SHAPE, dtype=np.int16),
+    "glyph_strs": dict(shape=GLYPH_STRS_SHAPE, dtype=np.uint8),
 }
 
 

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -22,10 +22,10 @@ INV_STRS_SHAPE = (
     _pynethack.nethack.NLE_INVENTORY_SIZE,
     _pynethack.nethack.NLE_INVENTORY_STR_LENGTH,
 )
+GLYPH_STRS_SHAPE = DUNGEON_SHAPE# DUNGEON_SHAPE + (_pynethack.nethack.NLE_GLYPH_STR_LENGTH,)
 
 OBSERVATION_DESC = {
     "glyphs": dict(shape=DUNGEON_SHAPE, dtype=np.int16),
-    "glyphs2": dict(shape=DUNGEON_SHAPE, dtype=np.int16),
     "chars": dict(shape=DUNGEON_SHAPE, dtype=np.uint8),
     "colors": dict(shape=DUNGEON_SHAPE, dtype=np.uint8),
     "specials": dict(shape=DUNGEON_SHAPE, dtype=np.uint8),
@@ -37,6 +37,7 @@ OBSERVATION_DESC = {
     "inv_letters": dict(shape=INV_SIZE, dtype=np.uint8),
     "inv_oclasses": dict(shape=INV_SIZE, dtype=np.uint8),
     "inv_strs": dict(shape=INV_STRS_SHAPE, dtype=np.uint8),
+    "glyph_strs": dict(shape=GLYPH_STRS_SHAPE, dtype=np.int16),
 }
 
 

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -25,6 +25,7 @@ INV_STRS_SHAPE = (
 
 OBSERVATION_DESC = {
     "glyphs": dict(shape=DUNGEON_SHAPE, dtype=np.int16),
+    "glyphs2": dict(shape=DUNGEON_SHAPE, dtype=np.int16),
     "chars": dict(shape=DUNGEON_SHAPE, dtype=np.uint8),
     "colors": dict(shape=DUNGEON_SHAPE, dtype=np.uint8),
     "specials": dict(shape=DUNGEON_SHAPE, dtype=np.uint8),

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -22,7 +22,9 @@ INV_STRS_SHAPE = (
     _pynethack.nethack.NLE_INVENTORY_SIZE,
     _pynethack.nethack.NLE_INVENTORY_STR_LENGTH,
 )
-GLYPH_STRS_SHAPE = DUNGEON_SHAPE + (_pynethack.nethack.NLE_GLYPH_STR_LENGTH,)
+SCREEN_DESCRIPTIONS_SHAPE = DUNGEON_SHAPE + (
+    _pynethack.nethack.NLE_SCREEN_DESCRIPTION_LENGTH,
+)
 
 OBSERVATION_DESC = {
     "glyphs": dict(shape=DUNGEON_SHAPE, dtype=np.int16),
@@ -37,7 +39,7 @@ OBSERVATION_DESC = {
     "inv_letters": dict(shape=INV_SIZE, dtype=np.uint8),
     "inv_oclasses": dict(shape=INV_SIZE, dtype=np.uint8),
     "inv_strs": dict(shape=INV_STRS_SHAPE, dtype=np.uint8),
-    "glyph_strs": dict(shape=GLYPH_STRS_SHAPE, dtype=np.uint8),
+    "screen_descriptions": dict(shape=SCREEN_DESCRIPTIONS_SHAPE, dtype=np.uint8),
 }
 
 

--- a/nle/tests/test_nethack.py
+++ b/nle/tests/test_nethack.py
@@ -338,11 +338,11 @@ class TestNethackGlanceObservation:
         game = nethack.Nethack()
         game.reset()
 
-        glyph_str_buff = game._obs_buffers["glyph_strs"]
+        screen_description_buff = game._obs_buffers["screen_descriptions"]
         glyph_buff = game._obs_buffers["glyphs"]
-        glance_shape = glyph_str_buff.shape
+        glance_shape = screen_description_buff.shape
         assert glyph_buff.shape == glance_shape[:2]
-        assert _pynethack.nethack.NLE_GLYPH_STR_LENGTH == glance_shape[-1]
+        assert _pynethack.nethack.NLE_SCREEN_DESCRIPTION_LENGTH == glance_shape[-1]
         assert len(glance_shape) == 3
 
     def test_glance_descriptions(self):
@@ -354,7 +354,7 @@ class TestNethackGlanceObservation:
         # rather naughty - testing against private impl
         glyph_buff = game._obs_buffers["glyphs"]
         char_buff = game._obs_buffers["chars"]
-        desc_buff = game._obs_buffers["glyph_strs"]
+        desc_buff = game._obs_buffers["screen_descriptions"]
 
         row, col = glyph_buff.shape
         episodes = 6

--- a/nle/tests/test_nethack.py
+++ b/nle/tests/test_nethack.py
@@ -331,3 +331,26 @@ class TestNethackFunctionsAndConstants:
         idx = nethack.glyph_to_obj(glyph)
         assert idx == elven_dagger.oc_name_idx
         assert nethack.objdescr.from_idx(idx) is od
+
+
+class TestNethackGlanceObservation:
+    def test_new_observation(self):
+        game = nethack.Nethack()
+        obs = game.reset()
+
+        new_obs_key = 'glyphs2'
+        np.set_printoptions(threshold=np.inf)
+        assert new_obs_key in nethack.OBSERVATION_DESC
+        assert new_obs_key in game._obs_buffers
+        np.testing.assert_equal(game._obs_buffers['glyphs'], game._obs_buffers[new_obs_key])
+        assert game._obs_buffers['glyphs'] is not game._obs_buffers[new_obs_key]
+        # do_screen_description(cc, looked, sym, *char outstr, firstmatch, permonst)
+        # const char *firstmatch = 0;
+        # sym=0, struct permonst *pm = 0, *supplemental_pm = 0;
+
+    def test_permonst(self):
+        mon = nethack.permonst(0)
+        assert mon.mname == "giant ant"
+        del mon
+
+        mon = nethack.permonst(1)

--- a/nle/tests/test_nethack.py
+++ b/nle/tests/test_nethack.py
@@ -336,7 +336,7 @@ class TestNethackFunctionsAndConstants:
 class TestNethackGlanceObservation:
     def test_new_observation_shapes(self):
         game = nethack.Nethack()
-        obs = game.reset()
+        game.reset()
 
         glyph_str_buff = game._obs_buffers["glyph_strs"]
         glyph_buff = game._obs_buffers["glyphs"]
@@ -349,7 +349,7 @@ class TestNethackGlanceObservation:
         game = nethack.Nethack(
             playername="MonkBot-mon-hum-neu-mal",
         )
-        obs = game.reset()[0]
+        game.reset()
 
         # rather naughty - testing against private impl
         glyph_buff = game._obs_buffers["glyphs"]
@@ -357,10 +357,9 @@ class TestNethackGlanceObservation:
         desc_buff = game._obs_buffers["glyph_strs"]
 
         row, col = glyph_buff.shape
-        str_len = _pynethack.nethack.NLE_GLYPH_STR_LENGTH
         episodes = 6
         for _ in range(episodes):
-            obs = game.reset()[0]
+            game.reset()
             for i in range(row):
                 for j in range(col):
                     glyph = glyph_buff[i][j]
@@ -384,4 +383,4 @@ class TestNethackGlanceObservation:
                         elif glyph == 2363:
                             assert glance == "wall"
                         elif glyph == 2372:
-                            assert glance == 'open door'
+                            assert glance == "open door"

--- a/nle/tests/test_nethack.py
+++ b/nle/tests/test_nethack.py
@@ -338,7 +338,7 @@ class TestNethackGlanceObservation:
         game = nethack.Nethack()
         obs = game.reset()
 
-        new_obs_key = 'glyphs2'
+        new_obs_key = 'glyph_strs'
         np.set_printoptions(threshold=np.inf)
         assert new_obs_key in nethack.OBSERVATION_DESC
         assert new_obs_key in game._obs_buffers

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -138,7 +138,7 @@ class Nethack
             checked_conversion<uint8_t>(inv_oclasses, { NLE_INVENTORY_SIZE });
         obs_.inv_strs = checked_conversion<uint8_t>(
             inv_strs, { NLE_INVENTORY_SIZE, NLE_INVENTORY_STR_LENGTH });
-        obs_.glyph_strs = checked_conversion<int16_t>(glyph_strs, dungeon);
+        obs_.glyph_strs = checked_conversion<uint8_t>(glyph_strs, {ROWNO, COLNO-1, NLE_GLYPH_STR_LENGTH});
 
         py_buffers_ = { std::move(glyphs),        std::move(chars),
                         std::move(colors),        std::move(specials),
@@ -260,6 +260,7 @@ PYBIND11_MODULE(_pynethack, m)
     mn.attr("NLE_INTERNAL_SIZE") = py::int_(NLE_INTERNAL_SIZE);
     mn.attr("NLE_INVENTORY_SIZE") = py::int_(NLE_INVENTORY_SIZE);
     mn.attr("NLE_INVENTORY_STR_LENGTH") = py::int_(NLE_INVENTORY_STR_LENGTH);
+    mn.attr("NLE_GLYPH_STR_LENGTH") = py::int_(NLE_GLYPH_STR_LENGTH);
 
     /* NetHack constants. */
     mn.attr("ROWNO") = py::int_(ROWNO);

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -138,15 +138,23 @@ class Nethack
             checked_conversion<uint8_t>(inv_oclasses, { NLE_INVENTORY_SIZE });
         obs_.inv_strs = checked_conversion<uint8_t>(
             inv_strs, { NLE_INVENTORY_SIZE, NLE_INVENTORY_STR_LENGTH });
-        obs_.screen_descriptions = checked_conversion<uint8_t>(screen_descriptions, {ROWNO, COLNO-1, NLE_SCREEN_DESCRIPTION_LENGTH});
+        obs_.screen_descriptions = checked_conversion<uint8_t>(
+            screen_descriptions,
+            { ROWNO, COLNO - 1, NLE_SCREEN_DESCRIPTION_LENGTH });
 
-        py_buffers_ = { std::move(glyphs),        std::move(chars),
-                        std::move(colors),        std::move(specials),
-                        std::move(blstats),       std::move(message),
-                        std::move(program_state), std::move(internal),
-                        std::move(inv_glyphs),    std::move(inv_letters),
-                        std::move(inv_oclasses),  std::move(inv_strs),
-                        std::move(screen_descriptions)};
+        py_buffers_ = { std::move(glyphs),
+                        std::move(chars),
+                        std::move(colors),
+                        std::move(specials),
+                        std::move(blstats),
+                        std::move(message),
+                        std::move(program_state),
+                        std::move(internal),
+                        std::move(inv_glyphs),
+                        std::move(inv_letters),
+                        std::move(inv_oclasses),
+                        std::move(inv_strs),
+                        std::move(screen_descriptions) };
     }
 
     void
@@ -260,7 +268,8 @@ PYBIND11_MODULE(_pynethack, m)
     mn.attr("NLE_INTERNAL_SIZE") = py::int_(NLE_INTERNAL_SIZE);
     mn.attr("NLE_INVENTORY_SIZE") = py::int_(NLE_INVENTORY_SIZE);
     mn.attr("NLE_INVENTORY_STR_LENGTH") = py::int_(NLE_INVENTORY_STR_LENGTH);
-    mn.attr("NLE_SCREEN_DESCRIPTION_LENGTH") = py::int_(NLE_SCREEN_DESCRIPTION_LENGTH);
+    mn.attr("NLE_SCREEN_DESCRIPTION_LENGTH") =
+        py::int_(NLE_SCREEN_DESCRIPTION_LENGTH);
 
     /* NetHack constants. */
     mn.attr("ROWNO") = py::int_(ROWNO);
@@ -369,20 +378,19 @@ PYBIND11_MODULE(_pynethack, m)
            [](int glyph) { return glyph_is_warning(glyph); });
 
     py::class_<permonst>(mn, "permonst", "The permonst struct.")
-        .def(
-            "__init__",
-            // See https://github.com/pybind/pybind11/issues/2394
-            [](py::detail::value_and_holder &v_h, int index) {
-                if (index < 0 || index >= NUMMONS)
-                    throw std::out_of_range(
-                        "Index should be between 0 and NUMMONS ("
-                        + std::to_string(NUMMONS) + ") but got "
-                        + std::to_string(index));
-                v_h.value_ptr() = &mons[index];
-                v_h.inst->owned = false;
-                v_h.set_holder_constructed(true);
-            },
-            py::detail::is_new_style_constructor())
+        .def("__init__",
+             // See https://github.com/pybind/pybind11/issues/2394
+             [](py::detail::value_and_holder &v_h, int index) {
+                 if (index < 0 || index >= NUMMONS)
+                     throw std::out_of_range(
+                         "Index should be between 0 and NUMMONS ("
+                         + std::to_string(NUMMONS) + ") but got "
+                         + std::to_string(index));
+                 v_h.value_ptr() = &mons[index];
+                 v_h.inst->owned = false;
+                 v_h.set_holder_constructed(true);
+             },
+             py::detail::is_new_style_constructor())
         .def_readonly("mname", &permonst::mname)   /* full name */
         .def_readonly("mlet", &permonst::mlet)     /* symbol */
         .def_readonly("mlevel", &permonst::mlevel) /* base monster level */
@@ -446,29 +454,28 @@ PYBIND11_MODULE(_pynethack, m)
         mn, "objclass",
         "The objclass struct.\n\n"
         "All fields are constant and don't reflect user changes.")
-        .def(
-            "__init__",
-            // See https://github.com/pybind/pybind11/issues/2394
-            [](py::detail::value_and_holder &v_h, int i) {
-                if (i < 0 || i >= NUM_OBJECTS)
-                    throw std::out_of_range(
-                        "Index should be between 0 and NUM_OBJECTS ("
-                        + std::to_string(NUM_OBJECTS) + ") but got "
-                        + std::to_string(i));
+        .def("__init__",
+             // See https://github.com/pybind/pybind11/issues/2394
+             [](py::detail::value_and_holder &v_h, int i) {
+                 if (i < 0 || i >= NUM_OBJECTS)
+                     throw std::out_of_range(
+                         "Index should be between 0 and NUM_OBJECTS ("
+                         + std::to_string(NUM_OBJECTS) + ") but got "
+                         + std::to_string(i));
 
-                /* Initialize. Cannot depend on o_init.c as it pulls
-                 * in all kinds of other code. Instead, do what
-                 * makedefs.c does at set it here.
-                 * Alternative: Get the pointer from the game itself?
-                 * Dangerous!
-                 */
-                objects[i].oc_name_idx = objects[i].oc_descr_idx = i;
+                 /* Initialize. Cannot depend on o_init.c as it pulls
+                  * in all kinds of other code. Instead, do what
+                  * makedefs.c does at set it here.
+                  * Alternative: Get the pointer from the game itself?
+                  * Dangerous!
+                  */
+                 objects[i].oc_name_idx = objects[i].oc_descr_idx = i;
 
-                v_h.value_ptr() = &objects[i];
-                v_h.inst->owned = false;
-                v_h.set_holder_constructed(true);
-            },
-            py::detail::is_new_style_constructor())
+                 v_h.value_ptr() = &objects[i];
+                 v_h.inst->owned = false;
+                 v_h.set_holder_constructed(true);
+             },
+             py::detail::is_new_style_constructor())
         .def_readonly("oc_name_idx",
                       &objclass::oc_name_idx) /* index of actual name */
         .def_readonly(

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -116,7 +116,7 @@ class Nethack
                 py::object program_state, py::object internal,
                 py::object inv_glyphs, py::object inv_letters,
                 py::object inv_oclasses, py::object inv_strs,
-                py::object glyph_strs)
+                py::object screen_descriptions)
     {
         std::vector<ssize_t> dungeon{ ROWNO, COLNO - 1 };
         obs_.glyphs = checked_conversion<int16_t>(glyphs, dungeon);
@@ -138,7 +138,7 @@ class Nethack
             checked_conversion<uint8_t>(inv_oclasses, { NLE_INVENTORY_SIZE });
         obs_.inv_strs = checked_conversion<uint8_t>(
             inv_strs, { NLE_INVENTORY_SIZE, NLE_INVENTORY_STR_LENGTH });
-        obs_.glyph_strs = checked_conversion<uint8_t>(glyph_strs, {ROWNO, COLNO-1, NLE_GLYPH_STR_LENGTH});
+        obs_.screen_descriptions = checked_conversion<uint8_t>(screen_descriptions, {ROWNO, COLNO-1, NLE_SCREEN_DESCRIPTION_LENGTH});
 
         py_buffers_ = { std::move(glyphs),        std::move(chars),
                         std::move(colors),        std::move(specials),
@@ -146,7 +146,7 @@ class Nethack
                         std::move(program_state), std::move(internal),
                         std::move(inv_glyphs),    std::move(inv_letters),
                         std::move(inv_oclasses),  std::move(inv_strs),
-                        std::move(glyph_strs)};
+                        std::move(screen_descriptions)};
     }
 
     void
@@ -243,7 +243,7 @@ PYBIND11_MODULE(_pynethack, m)
              py::arg("inv_letters") = py::none(),
              py::arg("inv_oclasses") = py::none(),
              py::arg("inv_strs") = py::none(),
-             py::arg("glyph_strs") = py::none())
+             py::arg("screen_descriptions") = py::none())
         .def("close", &Nethack::close)
         .def("set_initial_seeds", &Nethack::set_initial_seeds)
         .def("set_seeds", &Nethack::set_seeds)
@@ -260,7 +260,7 @@ PYBIND11_MODULE(_pynethack, m)
     mn.attr("NLE_INTERNAL_SIZE") = py::int_(NLE_INTERNAL_SIZE);
     mn.attr("NLE_INVENTORY_SIZE") = py::int_(NLE_INVENTORY_SIZE);
     mn.attr("NLE_INVENTORY_STR_LENGTH") = py::int_(NLE_INVENTORY_STR_LENGTH);
-    mn.attr("NLE_GLYPH_STR_LENGTH") = py::int_(NLE_GLYPH_STR_LENGTH);
+    mn.attr("NLE_SCREEN_DESCRIPTION_LENGTH") = py::int_(NLE_SCREEN_DESCRIPTION_LENGTH);
 
     /* NetHack constants. */
     mn.attr("ROWNO") = py::int_(ROWNO);

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -116,7 +116,7 @@ class Nethack
                 py::object program_state, py::object internal,
                 py::object inv_glyphs, py::object inv_letters,
                 py::object inv_oclasses, py::object inv_strs,
-                py::object glyphs2)
+                py::object glyph_strs)
     {
         std::vector<ssize_t> dungeon{ ROWNO, COLNO - 1 };
         obs_.glyphs = checked_conversion<int16_t>(glyphs, dungeon);
@@ -138,7 +138,7 @@ class Nethack
             checked_conversion<uint8_t>(inv_oclasses, { NLE_INVENTORY_SIZE });
         obs_.inv_strs = checked_conversion<uint8_t>(
             inv_strs, { NLE_INVENTORY_SIZE, NLE_INVENTORY_STR_LENGTH });
-        obs_.glyphs2 = checked_conversion<int16_t>(glyphs2, dungeon);
+        obs_.glyph_strs = checked_conversion<int16_t>(glyph_strs, dungeon);
 
         py_buffers_ = { std::move(glyphs),        std::move(chars),
                         std::move(colors),        std::move(specials),
@@ -146,7 +146,7 @@ class Nethack
                         std::move(program_state), std::move(internal),
                         std::move(inv_glyphs),    std::move(inv_letters),
                         std::move(inv_oclasses),  std::move(inv_strs),
-                        std::move(glyphs2)};
+                        std::move(glyph_strs)};
     }
 
     void
@@ -243,7 +243,7 @@ PYBIND11_MODULE(_pynethack, m)
              py::arg("inv_letters") = py::none(),
              py::arg("inv_oclasses") = py::none(),
              py::arg("inv_strs") = py::none(),
-             py::arg("glyphs2") = py::none())
+             py::arg("glyph_strs") = py::none())
         .def("close", &Nethack::close)
         .def("set_initial_seeds", &Nethack::set_initial_seeds)
         .def("set_seeds", &Nethack::set_seeds)

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -115,7 +115,8 @@ class Nethack
                 py::object specials, py::object blstats, py::object message,
                 py::object program_state, py::object internal,
                 py::object inv_glyphs, py::object inv_letters,
-                py::object inv_oclasses, py::object inv_strs)
+                py::object inv_oclasses, py::object inv_strs,
+                py::object glyphs2)
     {
         std::vector<ssize_t> dungeon{ ROWNO, COLNO - 1 };
         obs_.glyphs = checked_conversion<int16_t>(glyphs, dungeon);
@@ -137,13 +138,15 @@ class Nethack
             checked_conversion<uint8_t>(inv_oclasses, { NLE_INVENTORY_SIZE });
         obs_.inv_strs = checked_conversion<uint8_t>(
             inv_strs, { NLE_INVENTORY_SIZE, NLE_INVENTORY_STR_LENGTH });
+        obs_.glyphs2 = checked_conversion<int16_t>(glyphs2, dungeon);
 
         py_buffers_ = { std::move(glyphs),        std::move(chars),
                         std::move(colors),        std::move(specials),
                         std::move(blstats),       std::move(message),
                         std::move(program_state), std::move(internal),
                         std::move(inv_glyphs),    std::move(inv_letters),
-                        std::move(inv_oclasses),  std::move(inv_strs) };
+                        std::move(inv_oclasses),  std::move(inv_strs),
+                        std::move(glyphs2)};
     }
 
     void
@@ -239,7 +242,8 @@ PYBIND11_MODULE(_pynethack, m)
              py::arg("inv_glyphs") = py::none(),
              py::arg("inv_letters") = py::none(),
              py::arg("inv_oclasses") = py::none(),
-             py::arg("inv_strs") = py::none())
+             py::arg("inv_strs") = py::none(),
+             py::arg("glyphs2") = py::none())
         .def("close", &Nethack::close)
         .def("set_initial_seeds", &Nethack::set_initial_seeds)
         .def("set_seeds", &Nethack::set_seeds)

--- a/win/rl/winrl.cc
+++ b/win/rl/winrl.cc
@@ -277,7 +277,8 @@ NetHackRL::fill_obs(nle_obs *obs)
         if (obs->blstats)
             std::memset(obs->blstats, 0, sizeof(long) * NLE_BLSTATS_SIZE);
         if (obs->glyph_strs)
-            std::memset(obs->glyph_strs, 0, sizeof(uint8_t) * glyph_strs_.size());
+            std::memset(obs->glyph_strs, 0,
+                       sizeof(uint8_t) * glyph_strs_.size() * NLE_GLYPH_STR_LENGTH);
         return;
     }
     obs->in_normal_game = true;
@@ -411,7 +412,7 @@ NetHackRL::fill_obs(nle_obs *obs)
         int i = 0;
         for (const std::string &glyph_str : glyph_strs_) {
             int j = 0;
-            for (int size = glyph_str.size(); j < size; ++j){
+            for (int len = glyph_str.length(); j < len && j < NLE_GLYPH_STR_LENGTH; ++j){
                 obs->glyph_strs[i++] = glyph_str[j];
             }
             for (; j < NLE_GLYPH_STR_LENGTH; ++j){
@@ -507,7 +508,7 @@ NetHackRL::store_glyph_str(XCHAR_P x, XCHAR_P y, int glyph)
 
     if (do_screen_description(cc, TRUE, sym, tmpbuf, &firstmatch,
                               (struct permonst **) 0)) {
-      glyph_strs_[offset] = firstmatch;
+      glyph_strs_[offset].assign(firstmatch);
     } else {
       glyph_strs_[offset].clear();
     }
@@ -597,7 +598,9 @@ NetHackRL::clear_nhwindow_method(winid wid)
         chars_.fill(' ');
         colors_.fill(0);
         specials_.fill(0);
-        glyph_strs_.fill("");
+        for (std::string  &glyph_str : glyph_strs_) {
+          glyph_str.clear();
+        }
     }
 
     DEBUG_API("rl_clear_nhwindow(wid=" << wid << ")" << std::endl);

--- a/win/rl/winrl.cc
+++ b/win/rl/winrl.cc
@@ -278,7 +278,7 @@ NetHackRL::fill_obs(nle_obs *obs)
             std::memset(obs->blstats, 0, sizeof(long) * NLE_BLSTATS_SIZE);
         if (obs->screen_descriptions)
             std::memset(obs->screen_descriptions, 0,
-                       sizeof(uint8_t) * screen_descriptions_.size() * NLE_SCREEN_DESCRIPTION_LENGTH);
+                        screen_descriptions_.size() * NLE_SCREEN_DESCRIPTION_LENGTH);
         return;
     }
     obs->in_normal_game = true;

--- a/win/rl/winrl.cc
+++ b/win/rl/winrl.cc
@@ -178,7 +178,7 @@ class NetHackRL
     std::array<uint8_t, (COLNO - 1) * ROWNO> colors_;
     std::array<uint8_t, (COLNO - 1) * ROWNO> specials_;
 
-    std::array<int16_t, (COLNO - 1) * ROWNO> glyphs2_;
+    std::array<int16_t, (COLNO - 1) * ROWNO> glyph_strs_;
 
     void store_glyph(XCHAR_P x, XCHAR_P y, int glyph);
     void store_mapped_glyph(int ch, int color, int special, XCHAR_P x,
@@ -276,8 +276,8 @@ NetHackRL::fill_obs(nle_obs *obs)
             std::memset(obs->message, 0, 256);
         if (obs->blstats)
             std::memset(obs->blstats, 0, sizeof(long) * NLE_BLSTATS_SIZE);
-        if (obs->glyphs2)
-            std::memset(obs->glyphs2, 0, sizeof(int16_t) * glyphs2_.size());
+        if (obs->glyph_strs)
+            std::memset(obs->glyph_strs, 0, sizeof(int16_t) * glyph_strs_.size());
         return;
     }
     obs->in_normal_game = true;
@@ -407,9 +407,9 @@ NetHackRL::fill_obs(nle_obs *obs)
             obs->inv_oclasses[i] = MAXOCLASSES;
         }
     }
-    if (obs->glyphs2) {
-        std::memcpy(obs->glyphs2, glyphs2_.data(),
-                    sizeof(int16_t) * glyphs2_.size());
+    if (obs->glyph_strs) {
+        std::memcpy(obs->glyph_strs, glyph_strs_.data(),
+                    sizeof(int16_t) * glyph_strs_.size());
     }
 }
 
@@ -488,7 +488,7 @@ NetHackRL::store_glyph2(XCHAR_P x, XCHAR_P y, int glyph)
     size_t offset = j * (COLNO - 1) + i;
 
     // TODO: Glyphs might be taken from gbuf[y][x].glyph.
-    glyphs2_[offset] = glyph;
+    glyph_strs_[offset] = glyph;
 }
 
 void
@@ -574,7 +574,7 @@ NetHackRL::clear_nhwindow_method(winid wid)
         chars_.fill(' ');
         colors_.fill(0);
         specials_.fill(0);
-        glyphs2_.fill(0);
+        glyph_strs_.fill(0);
     }
 
     DEBUG_API("rl_clear_nhwindow(wid=" << wid << ")" << std::endl);

--- a/win/rl/winrl.cc
+++ b/win/rl/winrl.cc
@@ -178,12 +178,12 @@ class NetHackRL
     std::array<uint8_t, (COLNO - 1) * ROWNO> colors_;
     std::array<uint8_t, (COLNO - 1) * ROWNO> specials_;
     
-    std::array<std::string, (COLNO - 1) * ROWNO> glyph_strs_;
+    std::array<std::string, (COLNO - 1) * ROWNO> screen_descriptions_;
     
     void store_glyph(XCHAR_P x, XCHAR_P y, int glyph);
     void store_mapped_glyph(int ch, int color, int special, XCHAR_P x,
                             XCHAR_P y);
-    void store_glyph_str(XCHAR_P x, XCHAR_P y, int glyph);
+    void store_screen_description(XCHAR_P x, XCHAR_P y, int glyph);
 
     void fill_obs(nle_obs *);
     int getch_method();
@@ -276,9 +276,9 @@ NetHackRL::fill_obs(nle_obs *obs)
             std::memset(obs->message, 0, 256);
         if (obs->blstats)
             std::memset(obs->blstats, 0, sizeof(long) * NLE_BLSTATS_SIZE);
-        if (obs->glyph_strs)
-            std::memset(obs->glyph_strs, 0,
-                       sizeof(uint8_t) * glyph_strs_.size() * NLE_GLYPH_STR_LENGTH);
+        if (obs->screen_descriptions)
+            std::memset(obs->screen_descriptions, 0,
+                       sizeof(uint8_t) * screen_descriptions_.size() * NLE_SCREEN_DESCRIPTION_LENGTH);
         return;
     }
     obs->in_normal_game = true;
@@ -408,15 +408,15 @@ NetHackRL::fill_obs(nle_obs *obs)
             obs->inv_oclasses[i] = MAXOCLASSES;
         }
     }
-    if (obs->glyph_strs) {
+    if (obs->screen_descriptions) {
         int i = 0;
-        for (const std::string &glyph_str : glyph_strs_) {
+        for (const std::string &screen_description : screen_descriptions_) {
             int j = 0;
-            for (int len = glyph_str.length(); j < len && j < NLE_GLYPH_STR_LENGTH; ++j){
-                obs->glyph_strs[i++] = glyph_str[j];
+            for (int len = screen_description.length(); j < len && j < NLE_SCREEN_DESCRIPTION_LENGTH; ++j){
+                obs->screen_descriptions[i++] = screen_description[j];
             }
-            for (; j < NLE_GLYPH_STR_LENGTH; ++j){
-                obs->glyph_strs[i++] = 0;
+            for (; j < NLE_SCREEN_DESCRIPTION_LENGTH; ++j){
+                obs->screen_descriptions[i++] = 0;
             }
 
         }
@@ -490,7 +490,7 @@ NetHackRL::store_mapped_glyph(int ch, int color, int special, XCHAR_P x,
 }
 
 void
-NetHackRL::store_glyph_str(XCHAR_P x, XCHAR_P y, int glyph)
+NetHackRL::store_screen_description(XCHAR_P x, XCHAR_P y, int glyph)
 {
     // 1 <= x < cols, 0 <= y < rows (!)
     size_t i = (x - 1) % (COLNO - 1);
@@ -508,9 +508,9 @@ NetHackRL::store_glyph_str(XCHAR_P x, XCHAR_P y, int glyph)
 
     if (do_screen_description(cc, TRUE, sym, tmpbuf, &firstmatch,
                               (struct permonst **) 0)) {
-      glyph_strs_[offset].assign(firstmatch);
+      screen_descriptions_[offset].assign(firstmatch);
     } else {
-      glyph_strs_[offset].clear();
+      screen_descriptions_[offset].clear();
     }
 
 }
@@ -598,8 +598,8 @@ NetHackRL::clear_nhwindow_method(winid wid)
         chars_.fill(' ');
         colors_.fill(0);
         specials_.fill(0);
-        for (std::string  &glyph_str : glyph_strs_) {
-          glyph_str.clear();
+        for (std::string  &screen_description : screen_descriptions_) {
+          screen_description.clear();
         }
     }
 
@@ -883,7 +883,7 @@ NetHackRL::rl_print_glyph(winid wid, XCHAR_P x, XCHAR_P y, int glyph,
     if (wid == WIN_MAP) {
         instance->store_glyph(x, y, glyph);
         instance->store_mapped_glyph(ch, color, special, x, y);
-        instance->store_glyph_str(x, y, glyph);
+        instance->store_screen_description(x, y, glyph);
     } else {
         DEBUG_API("Window id is " << wid << ". This shouldn't happen."
                                   << std::endl);

--- a/win/rl/winrl.cc
+++ b/win/rl/winrl.cc
@@ -177,9 +177,9 @@ class NetHackRL
     std::array<uint8_t, (COLNO - 1) * ROWNO> chars_;
     std::array<uint8_t, (COLNO - 1) * ROWNO> colors_;
     std::array<uint8_t, (COLNO - 1) * ROWNO> specials_;
-    
+
     std::array<std::string, (COLNO - 1) * ROWNO> screen_descriptions_;
-    
+
     void store_glyph(XCHAR_P x, XCHAR_P y, int glyph);
     void store_mapped_glyph(int ch, int color, int special, XCHAR_P x,
                             XCHAR_P y);
@@ -278,7 +278,8 @@ NetHackRL::fill_obs(nle_obs *obs)
             std::memset(obs->blstats, 0, sizeof(long) * NLE_BLSTATS_SIZE);
         if (obs->screen_descriptions)
             std::memset(obs->screen_descriptions, 0,
-                        screen_descriptions_.size() * NLE_SCREEN_DESCRIPTION_LENGTH);
+                        screen_descriptions_.size()
+                            * NLE_SCREEN_DESCRIPTION_LENGTH);
         return;
     }
     obs->in_normal_game = true;
@@ -412,13 +413,13 @@ NetHackRL::fill_obs(nle_obs *obs)
         int i = 0;
         for (const std::string &screen_description : screen_descriptions_) {
             int j = 0;
-            for (int len = screen_description.length(); j < len && j < NLE_SCREEN_DESCRIPTION_LENGTH; ++j){
+            for (int len = screen_description.length();
+                 j < len && j < NLE_SCREEN_DESCRIPTION_LENGTH; ++j) {
                 obs->screen_descriptions[i++] = screen_description[j];
             }
-            for (; j < NLE_SCREEN_DESCRIPTION_LENGTH; ++j){
+            for (; j < NLE_SCREEN_DESCRIPTION_LENGTH; ++j) {
                 obs->screen_descriptions[i++] = 0;
             }
-
         }
     }
 }
@@ -508,11 +509,10 @@ NetHackRL::store_screen_description(XCHAR_P x, XCHAR_P y, int glyph)
 
     if (do_screen_description(cc, TRUE, sym, tmpbuf, &firstmatch,
                               (struct permonst **) 0)) {
-      screen_descriptions_[offset].assign(firstmatch);
+        screen_descriptions_[offset].assign(firstmatch);
     } else {
-      screen_descriptions_[offset].clear();
+        screen_descriptions_[offset].clear();
     }
-
 }
 
 void
@@ -598,8 +598,8 @@ NetHackRL::clear_nhwindow_method(winid wid)
         chars_.fill(' ');
         colors_.fill(0);
         specials_.fill(0);
-        for (std::string  &screen_description : screen_descriptions_) {
-          screen_description.clear();
+        for (std::string &screen_description : screen_descriptions_) {
+            screen_description.clear();
         }
     }
 
@@ -642,7 +642,7 @@ NetHackRL::add_menu_method(
     int attr,                   /* attribute for string (like putstr()) */
     const char *str,            /* menu string */
     bool preselected            /* item is marked as selected */
-)
+    )
 {
     DEBUG_API("rl_add_menu" << std::endl);
     tty_add_menu(wid, glyph, identifier, ch, gch, attr, str, preselected);


### PR DESCRIPTION
## Why?
Our representation of a single observation does not capture all of the information of the game state that is available to the user. For instance, information on whether an object is greased, rusted, blessed or cursed is only conveyed through text, often by 'glancing' at the map (';' action). Similarly, if there are many items on a map, a glyph id cannot convey that though text can ('many objects here').

## What?
This pull request adds an observation that is the equivalent of 'glancing' at every square on the map, before returning, with auto describe on.

## Performance
The big concern here is the performance implications of copying across upto 80 dungeons worth of data at a time.  Due to the nle architecture, you only pay for what you need (nice @heiner !) so this would only hit people who need the observation, but we should do some perf tests to see whether to turn this on by default.


 