### PR TITLE
Fix a bad memory leak.

### DIFF
--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -30,11 +30,11 @@ using namespace py::literals;
 
 template <typename T>
 T *
-checked_conversion(py::object obj, const std::vector<ssize_t> &shape)
+checked_conversion(py::handle h, const std::vector<ssize_t> &shape)
 {
-    if (obj.is_none())
+    if (h.is_none())
         return nullptr;
-    py::array array = py::array::ensure(obj.release());
+    py::array array = py::array::ensure(h);
     if (!array)
         throw std::runtime_error("Numpy array required");
 


### PR DESCRIPTION
It turns out I misunderstood what pybind11's py::array::ensure does.
Looking at the code superficially (https://github.com/pybind/pybind11/blob/master/include/pybind11/numpy.h#L785)
I assumed this function steals a reference, hence the call to
release(). But the reference is being stolen from the return value
of raw_array(), which returns a new reference. Hence ensure() itself
does not steal anything but in fact increases the refcount (and will
decref it in ~array).

Thanks to @yobibyte for both finding this issue and insisting that
it happens on the Python side (I thought this might be related to
malloc calls in NetHack itself).