### PR TITLE
Fix ncurses-related memory leak; various updates to help debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ set_target_properties(nethack PROPERTIES CXX_STANDARD 14 SUFFIX ".so")
 target_include_directories(nethack PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
                                           ${NLE_INC_GEN} /usr/local/include)
 target_link_directories(nethack PUBLIC /usr/local/lib)
+target_compile_definitions(nethack PUBLIC "$<$<CONFIG:DEBUG>:MONITOR_HEAP>")
 
 # On Ubuntu 20.04, libncurses6 seems to cause a SEGFAULT on tgetent?
 find_library(NCURSES_LIB NAMES libncurses.so.5 libncurses ncurses)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,9 @@ target_link_libraries(nethack PUBLIC m fcontext bz2 ${NCURSES_LIB})
 # dlopen wrapper library
 add_library(nethackdl STATIC "sys/unix/nledl.c")
 target_include_directories(nethackdl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(nethackdl PUBLIC dl ${NCURSES_LIB})
+target_link_libraries(nethackdl PUBLIC dl ncurses)
+# Would have liked to use ${NCURSES_LIB} in the last line, but CMake doesn't
+# include transitive dependencies when using absolute file names. :/
 
 # rlmain C++ (test) binary
 add_executable(rlmain "sys/unix/rlmain.cc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,14 +96,17 @@ target_link_directories(nethack PUBLIC /usr/local/lib)
 
 # On Ubuntu 20.04, libncurses6 seems to cause a SEGFAULT on tgetent?
 find_library(NCURSES_LIB NAMES libncurses.so.5 libncurses ncurses)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(TINFO_LIB "${NCURSES_LIB}")
+else()
+  find_library(TINFO_LIB NAMES libtinfo.so.5 libtinfo tinfo)
+endif()
 target_link_libraries(nethack PUBLIC m fcontext bz2 ${NCURSES_LIB})
 
 # dlopen wrapper library
 add_library(nethackdl STATIC "sys/unix/nledl.c")
 target_include_directories(nethackdl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(nethackdl PUBLIC dl ncurses)
-# Would have liked to use ${NCURSES_LIB} in the last line, but CMake doesn't
-# include transitive dependencies when using absolute file names. :/
+target_link_libraries(nethackdl PUBLIC dl ${TINFO_LIB})
 
 # rlmain C++ (test) binary
 add_executable(rlmain "sys/unix/rlmain.cc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,16 +90,18 @@ set_target_properties(nethack PROPERTIES CXX_STANDARD 14 SUFFIX ".so")
 target_include_directories(nethack PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
                                           ${NLE_INC_GEN} /usr/local/include)
 target_link_directories(nethack PUBLIC /usr/local/lib)
-target_compile_definitions(nethack PUBLIC "$<$<CONFIG:DEBUG>:MONITOR_HEAP>")
+
+# Careful with -DMONITOR_HEAP: Ironically, it fails to fclose FILE* heaplog.
+# target_compile_definitions(nethack PUBLIC "$<$<CONFIG:DEBUG>:MONITOR_HEAP>")
 
 # On Ubuntu 20.04, libncurses6 seems to cause a SEGFAULT on tgetent?
 find_library(NCURSES_LIB NAMES libncurses.so.5 libncurses ncurses)
-target_link_libraries(nethack PUBLIC m fcontext ${NCURSES_LIB} bz2)
+target_link_libraries(nethack PUBLIC m fcontext bz2 ${NCURSES_LIB})
 
 # dlopen wrapper library
 add_library(nethackdl STATIC "sys/unix/nledl.c")
 target_include_directories(nethackdl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(nethackdl PUBLIC dl)
+target_link_libraries(nethackdl PUBLIC dl ${NCURSES_LIB})
 
 # rlmain C++ (test) binary
 add_executable(rlmain "sys/unix/rlmain.cc")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,37 +1,22 @@
 # -*- mode: dockerfile -*-
 
-FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
+FROM ubuntu:20.04
 
 ARG PYTHON_VERSION=3.8
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -yq \
-    apt-transport-https \
-    ca-certificates \
-    gnupg \
-    wget \
-    git \
-    software-properties-common \
-    build-essential \
-    emacs \
-    vim \
-    python3-pip
-
-RUN apt-get update && apt-get install -y \
-    curl \
-    make \
-    g++ \
-    clang \
-    bison \
-    flex \
-    libncurses-dev
-
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
-
-RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-RUN apt-get update && apt-get --allow-unauthenticated install -yq \
-    cmake \
-    kitware-archive-keyring
+        bison \
+        build-essential \
+        cmake \
+        curl \
+        flex \
+        git \
+        libbz2-dev \
+        libncurses5 \  # NLE breaks with libncurses6.
+        libncurses5-dev \
+        ninja-build \
+        wget
 
 WORKDIR /opt/conda_setup
 
@@ -44,10 +29,20 @@ ENV PATH /opt/conda/bin:$PATH
 
 RUN python -m pip install --upgrade pip ipython ipdb
 
+COPY . /opt/nle/
+
 WORKDIR /opt/nle
 
-COPY . .
+RUN pip install '.[all]'
 
-RUN pip install ".[all]"
+WORKDIR /workspace
 
-WORKDIR '/workspace'
+CMD ["/bin/bash"]
+
+
+# Docker commands:
+#   docker rm nle -v
+#   docker build -t nle -f docker/Dockerfile .
+#   docker run --rm --name nle nle
+# or
+#   docker run -it --entrypoint /bin/bash nle

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ FROM ubuntu:20.04
 ARG PYTHON_VERSION=3.8
 ENV DEBIAN_FRONTEND=noninteractive
 
+# TODO(heiner): NLE breaks with libncurses6. Fix.
 RUN apt-get update && apt-get install -yq \
         bison \
         build-essential \
@@ -13,7 +14,7 @@ RUN apt-get update && apt-get install -yq \
         flex \
         git \
         libbz2-dev \
-        libncurses5 \  # NLE breaks with libncurses6.
+        libncurses5 \
         libncurses5-dev \
         ninja-build \
         wget

--- a/include/config.h
+++ b/include/config.h
@@ -27,6 +27,9 @@
 /* #define STUPID */ /* avoid some complicated expressions if
                         your C compiler chokes on them */
 /* #define MINIMAL_TERM */
+/* NLE TODO(heiner): Consider dropping TERMLIB this way. */
+/*#define ANSI_DEFAULT*/
+/*#undef TERMLIB*/
 /* if a terminal handles highlighting or tabs poorly,
    try this define, used in pager.c and termcap.c */
 /* #define ULTRIX_CC20 */

--- a/nle/scripts/play.py
+++ b/nle/scripts/play.py
@@ -152,6 +152,7 @@ def play(env, mode, ngames, max_steps, seeds, savedir, no_render, debug):
         if episodes == ngames:
             break
         env.reset()
+    env.close()
     print(
         "Finished after %i episodes and %f seconds. Mean sps: %f"
         % (episodes, timeit.default_timer() - total_start_time, mean_sps)

--- a/nle/scripts/read_heaplog.py
+++ b/nle/scripts/read_heaplog.py
@@ -1,0 +1,26 @@
+import collections
+import pprint
+
+Entry = collections.namedtuple("Entry", "size hash line file")
+
+
+def main():
+    allocs = {}
+    with open("heaplog.txt") as heaplog:
+        for line in heaplog:
+            entries = line.split()
+            if entries[0] == "+":
+                entry = Entry(*entries[1:])
+                allocs[entry.hash] = entry
+            else:
+                entry = Entry(None, *entries[1:])
+                if entry.hash not in allocs:
+                    print("dealloc not found in allocs:", line)
+                    continue
+                del allocs[entry.hash]
+
+    pprint.pprint(allocs)
+
+
+if __name__ == "__main__":
+    main()

--- a/nle/scripts/read_heaplog.py
+++ b/nle/scripts/read_heaplog.py
@@ -1,4 +1,5 @@
 import collections
+import sys
 import pprint
 
 Entry = collections.namedtuple("Entry", "size hash line file")
@@ -6,7 +7,7 @@ Entry = collections.namedtuple("Entry", "size hash line file")
 
 def main():
     allocs = {}
-    with open("heaplog.txt") as heaplog:
+    with open(sys.argv[1]) as heaplog:
         for line in heaplog:
             entries = line.split()
             if entries[0] == "+":

--- a/src/nle.c
+++ b/src/nle.c
@@ -4,6 +4,9 @@
 #include <sys/time.h>
 
 #define NEED_VARARGS
+#ifdef MONITOR_HEAP
+#undef MONITOR_HEAP
+#endif
 #include "hack.h"
 
 #include "dlb.h"

--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -4,6 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <curses.h>
+#include <term.h>
+
 #include "nledl.h"
 
 void
@@ -57,6 +60,16 @@ nle_ctx_t *
 nle_start(const char *dlpath, nle_obs *obs, FILE *ttyrec,
           nle_seeds_init_t *seed_init)
 {
+    static bool tc_started = FALSE;
+    if (!tc_started) {
+        const char *term = getenv("TERM");
+        if (!term || tgetent(NULL, term) < 1) {
+            fprintf(stderr, "Couldn't get terminal\n");
+            exit(EXIT_FAILURE);
+        }
+        tc_started = TRUE;
+    }
+
     /* TODO: Consider getting ttyrec path from caller? */
     struct nledl_ctx *nledl = malloc(sizeof(struct nledl_ctx));
     nledl->ttyrec = ttyrec;

--- a/sys/unix/rlmain.cc
+++ b/sys/unix/rlmain.cc
@@ -62,24 +62,23 @@ randplay(nle_ctx_t *nle, nle_obs *obs)
     };
     size_t n = sizeof(actions) / sizeof(actions[0]);
 
-    while (!obs->done) {
+    for (int i = 0; !obs->done && i < 10000; ++i) {
         obs->action = actions[rand() % n];
         nle = nle_step(nle, obs);
+    }
+    if (!obs->done) {
+        std::cerr << "Episode didn't end after 10000 steps, aborting."
+                  << std::endl;
     }
 }
 
 void
-randgame(nle_ctx_t *nle, nle_obs *obs)
+randgame(nle_ctx_t *nle, nle_obs *obs, const int no_episodes)
 {
-    obs->action = 'y';
-    nle_step(nle, obs);
-    nle_step(nle, obs);
-    obs->action = '\n';
-    nle_step(nle, obs);
-
-    for (int i = 0; i < 15; ++i) {
+    for (int i = 0; i < no_episodes; ++i) {
         randplay(nle, obs);
-        nle_reset(nle, obs, nullptr, nullptr);
+        if (i < no_episodes - 1)
+            nle_reset(nle, obs, nullptr, nullptr);
     }
 }
 
@@ -118,7 +117,7 @@ main(int argc, char **argv)
     ScopedTC tc;
     nle_ctx_t *nle = nle_start("libnethack.so", &obs, ttyrec.get(), nullptr);
     if (argc > 1 && argv[1][0] == 'r') {
-        randgame(nle, &obs);
+        randgame(nle, &obs, 3);
     } else {
         play(nle, &obs);
         nle_reset(nle, &obs, nullptr, nullptr);

--- a/win/tty/termcap.c
+++ b/win/tty/termcap.c
@@ -154,7 +154,7 @@ int *wid, *hgt;
 #endif
         TE = VS = VE = nullstr;
 #ifdef TEXTCOLOR
-        /* NLE: TODO(heiner): Re-enable and free these. */
+        /* NLE: TODO(heiner): Fix using ANSI_DEFAULT, free these. */
         for (i = 0; i < CLR_MAX / 2; i++)
             if (i != CLR_BLACK) {
                 hilites[i | BRIGHT] = (char *) alloc(sizeof("\033[1;3%dm"));


### PR DESCRIPTION
Fix a termcap/terminfo/termlib/ncurses related memory leak.

Even after recent fixes, we were still seeing memory leaks. This
commit fixes another one.

The terminfo/termcap library is a weird 1980s mess. Among other
things, it cannot clean up after itself. The tgetent(3) call allocs
some memory; it also sets some global state that tells it to re-use
that memory in future calls (most programs will call tgetent only
once; NLE and screen/tmux might be exceptions).

However, or dlopen/dlclose trick dynamically loaded AND UNLOADED
libncurses, which probably reset its global state, creating new
memory allocations for each tgetent call. Or perhaps calling tgetent
several times just leaks in every case.

This change moves the tgetent call up one level into nledl.c, and
only does it once (per environment). This appears to fix any memory
issues I could see with valgrind (although ncurses will always show
up there) and appears to not make ./rlmain r leak on Ubuntu, measured
with

    pmap -x $!.

On MacOS, (1) valgrind appears to show a number of entries, but they all
look like false positives or (2) are dlopen/dlclose-related or (3)
are tgetent-via-nle_start related. The practial memory behavior on
MacOS is harder to ascertain. Measuring with

    ps -axm -o pid,%mem,rss,comm | grep rlmain
shows a slooow increase with occasional drops. Certainly slower
than before :D

An alternative to this change would be to rip out ncurses altogether,
e.g. by #undef'ing TERMLIB and #define'ing ANSI_DEFAULT. Doing so
creates other memory leaks in the hilites array in termcap.c which
can probably be fixed too.