### PR TITLE
Drop ncurses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,19 +94,12 @@ target_link_directories(nethack PUBLIC /usr/local/lib)
 # Careful with -DMONITOR_HEAP: Ironically, it fails to fclose FILE* heaplog.
 # target_compile_definitions(nethack PUBLIC "$<$<CONFIG:DEBUG>:MONITOR_HEAP>")
 
-# On Ubuntu 20.04, libncurses6 seems to cause a SEGFAULT on tgetent?
-find_library(NCURSES_LIB NAMES libncurses.so.5 libncurses ncurses)
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set(TINFO_LIB "${NCURSES_LIB}")
-else()
-  find_library(TINFO_LIB NAMES libtinfo.so.5 libtinfo tinfo)
-endif()
-target_link_libraries(nethack PUBLIC m fcontext bz2 ${NCURSES_LIB})
+target_link_libraries(nethack PUBLIC m fcontext bz2)
 
 # dlopen wrapper library
 add_library(nethackdl STATIC "sys/unix/nledl.c")
 target_include_directories(nethackdl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(nethackdl PUBLIC dl ${TINFO_LIB})
+target_link_libraries(nethackdl PUBLIC dl)
 
 # rlmain C++ (test) binary
 add_executable(rlmain "sys/unix/rlmain.cc")

--- a/docker/Dockerfile.valgrind
+++ b/docker/Dockerfile.valgrind
@@ -1,0 +1,62 @@
+# -*- mode: dockerfile -*-
+
+FROM ubuntu:20.04
+
+ARG PYTHON_VERSION=3.8
+ENV DEBIAN_FRONTEND=noninteractive
+
+# TODO(heiner): NLE breaks with libncurses6. Fix.
+RUN apt-get update && apt-get install -yq \
+        bison \
+        build-essential \
+        cmake \
+        curl \
+        flex \
+        git \
+        libbz2-dev \
+        libncurses5 \
+        libncurses5-dev \
+        ninja-build \
+        wget
+
+WORKDIR /opt/conda_setup
+
+RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+     chmod +x miniconda.sh && \
+     ./miniconda.sh -b -p /opt/conda && \
+     /opt/conda/bin/conda install -y python=$PYTHON_VERSION && \
+     /opt/conda/bin/conda clean -ya
+ENV PATH /opt/conda/bin:$PATH
+
+RUN python -m pip install --upgrade pip ipython ipdb
+
+RUN pip install pybind11 numpy gym
+
+COPY . /opt/nle/
+
+WORKDIR /opt/nle
+
+RUN apt-get install -yq valgrind
+
+WORKDIR /opt/nle
+
+RUN rm -rf build
+
+WORKDIR /opt/nle/build
+
+RUN cmake -G Ninja -DCMAKE_BUILD_TYPE=debug ..
+
+RUN ninja && ninja install
+
+ENV LD_LIBRARY_PATH /opt/nle/build
+
+ENV NETHACKOPTIONS name:Agent-mon-hum-neu-mal
+
+CMD ["/bin/sh", "-c", "valgrind --leak-check=yes --leak-check=full --show-leak-kinds=all --log-file=valgrind.log --keep-debuginfo=yes ./rlmain r && cat valgrind.log"]
+
+# Docker commands:
+#   docker rm nle -v
+#   docker build -t nle -f docker/Dockerfile .
+#   docker run --rm --name nle nle
+# or
+#   docker run -it --entrypoint /bin/bash nle

--- a/include/config.h
+++ b/include/config.h
@@ -27,9 +27,7 @@
 /* #define STUPID */ /* avoid some complicated expressions if
                         your C compiler chokes on them */
 /* #define MINIMAL_TERM */
-/* NLE TODO(heiner): Consider dropping TERMLIB this way. */
-/*#define ANSI_DEFAULT*/
-/*#undef TERMLIB*/
+#define ANSI_DEFAULT  /* NLE: Don't #define TERMLIB in tcap.h, use this. */
 /* if a terminal handles highlighting or tabs poorly,
    try this define, used in pager.c and termcap.c */
 /* #define ULTRIX_CC20 */

--- a/include/tcap.h
+++ b/include/tcap.h
@@ -9,7 +9,9 @@
 #define TCAP_H
 
 #ifndef MICRO
+#ifndef RL_GRAPHICS
 #define TERMLIB /* include termcap code */
+#endif
 #endif
 
 /* might display need graphics code? */

--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -4,9 +4,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <curses.h>
-#include <term.h>
-
 #include "nledl.h"
 
 void
@@ -60,16 +57,6 @@ nle_ctx_t *
 nle_start(const char *dlpath, nle_obs *obs, FILE *ttyrec,
           nle_seeds_init_t *seed_init)
 {
-    static bool tc_started = FALSE;
-    if (!tc_started) {
-        const char *term = getenv("TERM");
-        if (!term || tgetent(NULL, term) < 1) {
-            fprintf(stderr, "Couldn't get terminal\n");
-            exit(EXIT_FAILURE);
-        }
-        tc_started = TRUE;
-    }
-
     /* TODO: Consider getting ttyrec path from caller? */
     struct nledl_ctx *nledl = malloc(sizeof(struct nledl_ctx));
     nledl->ttyrec = ttyrec;

--- a/sys/unix/rlmain.cc
+++ b/sys/unix/rlmain.cc
@@ -14,7 +14,7 @@ extern "C" {
 class ScopedTC
 {
   public:
-    ScopedTC()
+    ScopedTC() : old_{}
     {
         tcgetattr(STDIN_FILENO, &old_);
         struct termios tty = old_;

--- a/win/tty/termcap.c
+++ b/win/tty/termcap.c
@@ -154,7 +154,6 @@ int *wid, *hgt;
 #endif /* MICRO */
         TE = VS = VE = nullstr;
 #ifdef TEXTCOLOR
-        /* NLE: TODO(heiner): Fix using ANSI_DEFAULT, free these. */
         for (i = 0; i < CLR_MAX / 2; i++)
             if (i != CLR_BLACK) {
                 hilites[i | BRIGHT] = (char *) alloc(sizeof("\033[1;3%dm"));
@@ -333,6 +332,22 @@ tty_shutdown()
         free((genericptr_t) nh_HE), nh_HE = (char *) 0;
         dynamic_HIHE = FALSE;
     }
+#else /* TERMLIB */
+#ifndef TOS
+#if defined(ANSI_DEFAULT) && defined(TEXTCOLOR)
+    for (int i = 0; i < CLR_MAX / 2; i++)
+        if (i != CLR_BLACK) {
+            free(hilites[i | BRIGHT]);
+            if (i != CLR_GRAY)
+#ifdef MICRO
+                if (i != CLR_BLUE)
+#endif /* MICRO */
+                {
+                    free(hilites[i]);
+                }
+        }
+#endif /* ANSI_DEFAULT) && TEXTCOLOR */
+#endif /* TOS */
 #endif /* TERMLIB */
     return;
 }
@@ -1106,8 +1121,8 @@ kill_hilite()
 #endif /* TOS */
     return;
 }
-#endif /* UNIX */
-#endif /* TEXTCOLOR */
+#endif /* UNIX && TERMINFO */
+#endif /* TEXTCOLOR && TERMLIB */
 
 static char nulstr[] = "";
 

--- a/win/tty/termcap.c
+++ b/win/tty/termcap.c
@@ -339,6 +339,7 @@ tty_shutdown()
         if (i != CLR_BLACK) {
             free(hilites[i | BRIGHT]);
             if (i != CLR_GRAY)
+            /* Mirrors logic in tty_startup if ANSI_DEFAULT is set. */
 #ifdef MICRO
                 if (i != CLR_BLUE)
 #endif /* MICRO */

--- a/win/tty/termcap.c
+++ b/win/tty/termcap.c
@@ -12,7 +12,7 @@
 
 #ifdef MICROPORT_286_BUG
 #define Tgetstr(key) (tgetstr(key, tbuf))
-#else
+#else /* MICROPORT_286_BUG */
 #define Tgetstr(key) (tgetstr(key, &tbufptr))
 #endif /* MICROPORT_286_BUG **/
 
@@ -25,11 +25,11 @@ void FDECL(nocmov, (int, int));
 #if !defined(UNIX) || !defined(TERMINFO)
 #ifndef TOS
 static void FDECL(analyze_seq, (char *, int *, int *));
-#endif
-#endif
+#endif /* TOS */
+#endif /* !defined(UNIX) || !defined(TERMINFO) */
 static void NDECL(init_hilite);
 static void NDECL(kill_hilite);
-#endif
+#endif /* defined(TEXTCOLOR) && defined(TERMLIB) */
 
 /* (see tcap.h) -- nh_CM, nh_ND, nh_CD, nh_HI,nh_HE, nh_US,nh_UE, ul_hack */
 struct tc_lcl_data tc_lcl_data = { 0, 0, 0, 0, 0, 0, 0, FALSE };
@@ -48,25 +48,25 @@ STATIC_VAR char tbuf[512];
 #ifdef TEXTCOLOR
 #ifdef TOS
 const char *hilites[CLR_MAX]; /* terminal escapes for the various colors */
-#else
+#else /* TOS */
 char NEARDATA *hilites[CLR_MAX]; /* terminal escapes for the various colors */
-#endif
-#endif
+#endif /* TOS */
+#endif /* TEXTCOLOR */
 
 static char *KS = (char *) 0, *KE = (char *) 0; /* keypad sequences */
 static char nullstr[] = "";
 
 #if defined(ASCIIGRAPH) && !defined(NO_TERMS)
 extern boolean HE_resets_AS;
-#endif
+#endif /* defined(ASCIIGRAPH) && !defined(NO_TERMS) */
 
 #ifndef TERMLIB
 STATIC_VAR char tgotobuf[20];
 #ifdef TOS
 #define tgoto(fmt, x, y) (Sprintf(tgotobuf, fmt, y + ' ', x + ' '), tgotobuf)
-#else
+#else /* TOS */
 #define tgoto(fmt, x, y) (Sprintf(tgotobuf, fmt, y + 1, x + 1), tgotobuf)
-#endif
+#endif /* TOS */
 #endif /* TERMLIB */
 
 void
@@ -82,18 +82,18 @@ int *wid, *hgt;
 #ifdef VMS
     term = verify_termcap();
     if (!term)
-#endif
+#endif /* VMS */
         term = getenv("TERM");
 
 #if defined(TOS) && defined(__GNUC__)
     if (!term)
         term = "builtin"; /* library has a default */
-#endif
+#endif /* defined(TOS) && defined(__GNUC__) */
     if (!term)
-#endif
+#endif /* TERMLIB */
 #ifndef ANSI_DEFAULT
         error("Can't get TERM.");
-#else
+#else /* ANSI_DEFAULT */
 #ifdef TOS
     {
         CO = 80;
@@ -123,24 +123,24 @@ int *wid, *hgt;
 #ifdef CLIPPING
         if (CO < COLNO || LI < ROWNO + 3)
             setclipped();
-#endif
-#endif
+#endif /* CLIPPING */
+#endif /* MICRO */
         HO = "\033[H";
         /*              nh_CD = "\033[J"; */
         CE = "\033[K"; /* the ANSI termcap */
 #ifndef TERMLIB
         nh_CM = "\033[%d;%dH";
-#else
+#else /* TERMLIB */
         nh_CM = "\033[%i%d;%dH";
-#endif
+#endif /* TERMLIB */
         UP = "\033[A";
         nh_ND = "\033[C";
         XD = "\033[B";
 #ifdef MICRO /* backspaces are non-destructive */
         BC = "\b";
-#else
+#else /* MICRO  */
         BC = "\033[D";
-#endif
+#endif /* MICRO  */
         nh_HI = SO = "\033[1m";
         nh_US = "\033[4m";
         MR = "\033[7m";
@@ -151,7 +151,7 @@ int *wid, *hgt;
 #ifndef MICRO
         AS = "\016";
         AE = "\017";
-#endif
+#endif /* MICRO */
         TE = VS = VE = nullstr;
 #ifdef TEXTCOLOR
         /* NLE: TODO(heiner): Fix using ANSI_DEFAULT, free these. */
@@ -164,7 +164,7 @@ int *wid, *hgt;
                     if (i == CLR_BLUE)
                         hilites[CLR_BLUE] = hilites[CLR_BLUE | BRIGHT];
                     else
-#endif
+#endif /* MICRO */
                     {
                         hilites[i] = (char *) alloc(sizeof("\033[0;3%dm"));
                         Sprintf(hilites[i], "\033[0;3%dm", i);
@@ -196,23 +196,23 @@ int *wid, *hgt;
     if (!(BC = Tgetstr("le"))) /* both termcap and terminfo use le */
 #ifdef TERMINFO
         error("Terminal must backspace.");
-#else
+#else /* TERMINFO */
         if (!(BC = Tgetstr("bc"))) { /* termcap also uses bc/bs */
 #ifndef MINIMAL_TERM
             if (!tgetflag("bs"))
                 error("Terminal must backspace.");
-#endif
+#endif /* MINIMAL_TERM */
             BC = tbufptr;
             tbufptr += 2;
             *BC = '\b';
         }
-#endif
+#endif /* TERMINFO */
 
 #ifdef MINIMAL_TERM
     HO = (char *) 0;
-#else
+#else /* MINIMAL_TERM */
     HO = Tgetstr("ho");
-#endif
+#endif /* MINIMAL_TERM */
     /*
      * LI and CO are set in ioctl.c via a TIOCGWINSZ if available.  If
      * the kernel has values for either we should use them rather than
@@ -223,12 +223,12 @@ int *wid, *hgt;
         CO = tgetnum("co");
     if (!LI)
         LI = tgetnum("li");
-#else
+#else /* MICRO */
 #if defined(TOS) && defined(__GNUC__)
     if (!strcmp(term, "builtin")) {
         get_scr_size();
     } else
-#endif
+#endif /* defined(TOS) && defined(__GNUC__) */
     {
         CO = tgetnum("co");
         LI = tgetnum("li");
@@ -239,7 +239,7 @@ int *wid, *hgt;
 #ifdef CLIPPING
     if (CO < COLNO || LI < ROWNO + 3)
         setclipped();
-#endif
+#endif /* CLIPPING */
     nh_ND = Tgetstr("nd");
     if (tgetflag("os"))
         error("NetHack can't have OS.");
@@ -271,7 +271,7 @@ int *wid, *hgt;
     VS = VE = nullstr;
 #ifdef TERMINFO
     VS = Tgetstr("eA"); /* enable graphics */
-#endif
+#endif /* TERMINFO */
     KS = Tgetstr("ks"); /* keypad start (special mode) */
     KE = Tgetstr("ke"); /* keypad end (ordinary mode [ie, digits]) */
     MR = Tgetstr("mr"); /* reverse */
@@ -304,10 +304,10 @@ int *wid, *hgt;
         || !strcmp(term, "st52")) {
         init_hilite();
     }
-#else
+#else /* defined(TOS) && defined(__GNUC__) */
     init_hilite();
-#endif
-#endif
+#endif /* defined(TOS) && defined(__GNUC__) */
+#endif /* TEXTCOLOR */
     *wid = CO;
     *hgt = LI;
     if (!(CL = Tgetstr("cl"))) /* last thing set */
@@ -327,13 +327,13 @@ tty_shutdown()
 #ifdef TERMLIB
 #ifdef TEXTCOLOR
     kill_hilite();
-#endif
+#endif /* TEXTCOLOR */
     if (dynamic_HIHE) {
         free((genericptr_t) nh_HI), nh_HI = (char *) 0;
         free((genericptr_t) nh_HE), nh_HE = (char *) 0;
         dynamic_HIHE = FALSE;
     }
-#endif
+#endif /* TERMLIB */
     return;
 }
 
@@ -393,7 +393,7 @@ tty_decgraphics_termcap_fixup()
         xputs("\033)0");
 #ifdef PC9800
     init_hilite();
-#endif
+#endif /* PC9800 */
 
 #if defined(ASCIIGRAPH) && !defined(NO_TERMS)
     /* some termcaps suffer from the bizarre notion that resetting
@@ -425,13 +425,13 @@ tty_decgraphics_termcap_fixup()
             ++nh_he, --he_limit;
         }
     }
-#endif
+#endif /* defined(ASCIIGRAPH) && !defined(NO_TERMS) */
 }
 #endif /* TERMLIB */
 
 #if defined(ASCIIGRAPH) && defined(PC9800)
 extern void NDECL((*ibmgraphics_mode_callback)); /* defined in drawing.c */
-#endif
+#endif /* defined(ASCIIGRAPH) && defined(PC9800) */
 
 #ifdef PC9800
 extern void NDECL((*ascgraphics_mode_callback)); /* defined in drawing.c */
@@ -469,7 +469,7 @@ tty_start_screen()
         init_hilite();
     /* set up callback in case option is not set yet but toggled later */
     ibmgraphics_mode_callback = init_hilite;
-#endif
+#endif /* ASCIIGRAPH */
 #endif /* PC9800 */
 
 #ifdef TERMLIB
@@ -477,7 +477,7 @@ tty_start_screen()
         tty_decgraphics_termcap_fixup();
     /* set up callback in case option is not set yet but toggled later */
     decgraphics_mode_callback = tty_decgraphics_termcap_fixup;
-#endif
+#endif /* TERMLIB */
     if (Cmd.num_pad)
         tty_number_pad(1); /* make keypad send digits */
 }
@@ -586,12 +586,12 @@ const char *s;
 {
 #ifdef RL_GRAPHICS
     nle_xputs(s);
-#else
+#else /* RL_GRAPHICS */
 #ifndef TERMLIB
     (void) fputs(s, stdout);
-#else
+#else /* TERMLIB */
     tputs(s, 1, xputc);
-#endif
+#endif /* TERMLIB */
 #endif /*RL_GRAPHICS*/
 }
 
@@ -719,7 +719,7 @@ graph_off()
     if (AE)
         xputs(AE);
 }
-#endif
+#endif /* ASCIIGRAPH */
 
 #if !defined(MICRO)
 #ifdef VMS
@@ -727,13 +727,13 @@ static const short tmspc10[] = { /* from termcap */
                                  0, 2000, 1333, 909, 743, 666, 333, 166, 83,
                                  55, 50, 41, 27, 20, 13, 10, 5
 };
-#else
+#else /* VMS */
 static const short tmspc10[] = { /* from termcap */
                                  0, 2000, 1333, 909, 743, 666, 500, 333, 166,
                                  83, 55, 41, 20, 10, 5
 };
-#endif
-#endif
+#endif /* VMS */
+#endif /* !defined(MICRO) */
 
 /* NLE: Don't delay ever. */
 void
@@ -800,7 +800,7 @@ cl_eos() /* free after Robert Viduya */
 
 #if !defined(LINUX) && !defined(__FreeBSD__) && !defined(NOTPARMDECL)
 extern char *tparm();
-#endif
+#endif /* !defined(LINUX) && !defined(__FreeBSD__) && !defined(NOTPARMDECL) */
 
 #ifndef COLOR_BLACK /* trust include file */
 #ifndef _M_UNIX     /* guess BGR */
@@ -821,8 +821,8 @@ extern char *tparm();
 #define COLOR_MAGENTA 5
 #define COLOR_CYAN 6
 #define COLOR_WHITE 7
-#endif
-#endif
+#endif /* _M_UNIX      */
+#endif /* COLOR_BLACK  */
 
 /* Mapping data for the six terminfo colors that resolve to pairs of nethack
  * colors.  Black and white are handled specially.
@@ -955,9 +955,9 @@ int *fg, *bg;
 #ifdef MICRO
     *fg = CLR_GRAY;
     *bg = CLR_BLACK;
-#else
+#else /* MICRO */
     *fg = *bg = NO_COLOR;
-#endif
+#endif /* MICRO */
 
     c = (str[0] == '\233') ? 1 : 2; /* index of char beyond esc prefix */
     len = strlen(str) - 1;          /* length excluding attrib suffix */
@@ -971,9 +971,9 @@ int *fg, *bg;
 #ifdef MICRO
             *fg = CLR_GRAY;
             *bg = CLR_BLACK;
-#else
+#else /* MICRO */
             *fg = *bg = NO_COLOR;
-#endif
+#endif /* MICRO */
         } else if (code == 1) { /* bold */
             *fg |= BRIGHT;
 #if 0
@@ -984,7 +984,7 @@ int *fg, *bg;
             *fg |= BLINK;
         } else if (code == 25) { /* stop blinking */
             *fg &= ~BLINK;
-#endif
+#endif /* 0 */
         } else if (code == 7 || code == 27) { /* reverse */
             code = *fg & ~BRIGHT;
             *fg = *bg | (*fg & BRIGHT);
@@ -999,7 +999,7 @@ int *fg, *bg;
         c++;
     }
 }
-#endif
+#endif /* TOS */
 
 /*
  * Sets up highlighting sequences, using ANSI escape sequences (highlight code
@@ -1068,7 +1068,7 @@ init_hilite()
 #ifdef MICRO
             if (c == CLR_BLUE)
                 continue;
-#endif
+#endif /* MICRO */
             if (c == foreg)
                 hilites[c] = (char *) 0;
             else if (c != hi_foreg || backg != hi_backg) {
@@ -1085,7 +1085,7 @@ init_hilite()
 #ifdef MICRO
     /* brighten low-visibility colors */
     hilites[CLR_BLUE] = hilites[CLR_BLUE | BRIGHT];
-#endif
+#endif /* MICRO */
 #endif /* TOS */
 }
 
@@ -1103,7 +1103,7 @@ kill_hilite()
         if (hilites[c | BRIGHT] && (hilites[c | BRIGHT] != nh_HI))
             free((genericptr_t) hilites[c | BRIGHT]), hilites[c | BRIGHT] = 0;
     }
-#endif
+#endif /* TOS */
     return;
 }
 #endif /* UNIX */


### PR DESCRIPTION
This PR removes ncurses as a dependency. It also makes for a nice Valgrind output:

```sh
nle$ docker build -t nle -f docker/Dockerfile.valgrind .
nle$ docker run --rm --name nle nle
==7== Memcheck, a memory error detector
==7== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==7== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==7== Command: ./rlmain r
==7== Parent PID: 1
==7==
==7== Warning: client switching stacks?  SP change: 0x1ffeffe6a8 --> 0x5977fc0
==7==          to suppress, use: --max-stackframe=137328355048 or greater
==7== Warning: client switching stacks?  SP change: 0x5977a88 --> 0x1ffeffe6a8
==7==          to suppress, use: --max-stackframe=137328356384 or greater
==7== Warning: client switching stacks?  SP change: 0x1ffeffe678 --> 0x5977a88
==7==          to suppress, use: --max-stackframe=137328356336 or greater
==7==          further instances of this message will not be shown.
==7==
==7== HEAP SUMMARY:
==7==     in use at exit: 0 bytes in 0 blocks
==7==   total heap usage: 23,544 allocs, 23,544 frees, 23,612,096 bytes allocated
==7==
==7== All heap blocks were freed -- no leaks are possible
==7==
==7== For lists of detected and suppressed errors, rerun with: -s
==7== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**0 bytes in 0 blocks** used at exit. This definitely fixes #120, although probably the last PR did that already. 