### PR TITLE
Fixup the test PyPI install workflow.

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -4,6 +4,9 @@ name: Test nle PyPI package
 on:
   schedule:
     - cron: "0 6,18 * * *"
+  push:
+    branches:
+      - eric/workflows
 
 jobs:
   test_install:

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -26,4 +26,5 @@ jobs:
     - name: Install nle via pip
       run: "pip install nle"
     - name: Check nethack is installed
-      run: "python -c 'import nle; import gym; gym.make(\"NetHack-v0\")'"
+      run: |
+        python -c 'import nle, gym; e = gym.make("NetHack-v0"); e.reset(); e.step(0)' 

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -26,8 +26,6 @@ jobs:
     - name: Install dependencies
       run: |
         brew install cmake
-    - name: Clone repo
-      uses: actions/checkout@v2
     - name: Install nle via pip
       run: "pip install nle"
     - name: Check nethack is installed

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -4,9 +4,6 @@ name: Test nle PyPI package
 on:
   schedule:
     - cron: "0 6,18 * * *"
-  push:
-    branches:
-      - eric/workflows
 
 jobs:
   test_install:

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -154,7 +154,7 @@ class Nethack:
         # TODO ideally we need to check the validity of the requested items
         with open(os.path.join(self._vardir, WIZKIT_FNAME), "w") as f:
             for item in wizkit_items:
-                f.write("{}\n".format(item))
+                f.write("%s\n" % item)
 
     def reset(self, new_ttyrec=None, wizkit_items=None):
         if wizkit_items is not None:

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -154,7 +154,7 @@ class Nethack:
         # TODO ideally we need to check the validity of the requested items
         with open(os.path.join(self._vardir, WIZKIT_FNAME), "w") as f:
             for item in wizkit_items:
-                f.write(f"{item}\n")
+                f.write("{}\n".format(item))
 
     def reset(self, new_ttyrec=None, wizkit_items=None):
         if wizkit_items is not None:


### PR DESCRIPTION
The current `test_package.yml` workflow test has been broken for 4 months.  I assume it aims to test the nle packages from PyPI but it seems a bit confused, since there is a clone step in it.  Furthermore I cant tell if the purpose of this workflow changed, since the description of the key installation step changed from 'Install from repo in test mode" to  "Install nle via pip" a few months ago to accurately reflect the executed command. Perhaps this was a copy job from a workflow that tests installation from the repo?

At any rate the workflow was failing due to the fact that the cloned local `nle` was being accessed in the final step and it doesnt have the pynethack built, since nle was installed via pip.  Removing the cloned repo has the desired effect.

[Old test](https://github.com/facebookresearch/nle/actions/runs/362831941)
[New test (still fails due on 3.5 due to f strings)](https://github.com/facebookresearch/nle/actions/runs/363227992)

Btw to trigger this new workflow I had to add a section to the yaml, which should be visible in the intermittent PR history. 