### PR TITLE
Add benchmarks sps profile test.

### DIFF
--- a/nle/scripts/check_nethack_speed.py
+++ b/nle/scripts/check_nethack_speed.py
@@ -28,7 +28,7 @@ def target(i, should_stop, queue):
 
 
 def play(should_stop, queue):
-    game = nethack.NetHack(archivefile=None)
+    game = nethack.Nethack()
 
     done = True
     steps = 0
@@ -39,12 +39,9 @@ def play(should_stop, queue):
             steps = 0
             observation = game.reset()
 
-        if observation.Internal() and observation.Internal().Xwaitforspace():
-            ch = nethack.MiscAction.MORE
-        else:
-            ch = random.choice(ACTIONS)
+        ch = random.choice(ACTIONS)
 
-        observation, done, _ = game.step(ch)
+        observation, done = game.step(ch)
         steps += 1
 
 

--- a/nle/tests/test_nethack.py
+++ b/nle/tests/test_nethack.py
@@ -334,7 +334,15 @@ class TestNethackFunctionsAndConstants:
 
 
 class TestNethackGlanceObservation:
-    def test_new_observation_shapes(self):
+    @pytest.fixture
+    def game(self):  # Make sure we close even on test failure.
+        g = nethack.Nethack(playername="MonkBot-mon-hum-neu-mal")
+        try:
+            yield g
+        finally:
+            g.close()
+
+    def test_new_observation_shapes(self, game):
         game = nethack.Nethack()
         game.reset()
 
@@ -345,10 +353,7 @@ class TestNethackGlanceObservation:
         assert _pynethack.nethack.NLE_SCREEN_DESCRIPTION_LENGTH == glance_shape[-1]
         assert len(glance_shape) == 3
 
-    def test_glance_descriptions(self):
-        game = nethack.Nethack(
-            playername="MonkBot-mon-hum-neu-mal",
-        )
+    def test_glance_descriptions(self, game):
         game.reset()
 
         # rather naughty - testing against private impl

--- a/nle/tests/test_profile.py
+++ b/nle/tests/test_profile.py
@@ -5,8 +5,6 @@
 import pytest
 
 import nle
-from nle.nethack import OBSERVATION_DESC
-import gym
 import numpy as np
 
 

--- a/nle/tests/test_profile.py
+++ b/nle/tests/test_profile.py
@@ -9,14 +9,23 @@ from nle.nethack import OBSERVATION_DESC
 import gym
 import numpy as np
 
-ACTIONS = [nle.nethack.MiscAction.MORE]
-ACTIONS += list(nle.nethack.CompassDirection)
-ACTIONS += list(nle.nethack.CompassDirectionLonger)
 
+BASE_KEYS = ['glyphs', 'message', 'blstats']
+MAPPED_GLYPH = ['chars', 'colors', 'specials']
+INV_GLYPH = ['inv_glyphs', 'inv_strs', 'inv_letters', 'inv_oclasses']
+SCREEN_DESC = ['screen_descriptions']
+
+OBS_KEYS = [
+    BASE_KEYS,
+    BASE_KEYS + MAPPED_GLYPH,
+    BASE_KEYS + MAPPED_GLYPH + INV_GLYPH,
+    BASE_KEYS + MAPPED_GLYPH + INV_GLYPH + SCREEN_DESC
+]
+
+@pytest.mark.parametrize('observation_keys', OBS_KEYS)
 @pytest.mark.benchmark(min_rounds=30, disable_gc=True, warmup=False)
-def test_1k_steps_performance(benchmark):
-    obs = [o for o in OBSERVATION_DESC.keys() if o not in ['screen_descriptions']]
-    env = nle.env.base.NLE(observation_keys=obs  )
+def test_1k_steps_performance(observation_keys, benchmark):
+    env = nle.env.base.NLE(observation_keys=observation_keys)
 
     steps = 1000
     actions = np.random.choice(len(env._actions), size=steps)

--- a/nle/tests/test_profile.py
+++ b/nle/tests/test_profile.py
@@ -6,7 +6,7 @@ import pytest
 
 import nle
 import numpy as np
-
+import gym
 
 BASE_KEYS = ["glyphs", "message", "blstats"]
 MAPPED_GLYPH = ["chars", "colors", "specials"]
@@ -27,7 +27,7 @@ EXPERIMENTS = {
 )
 @pytest.mark.benchmark(disable_gc=True, warmup=False)
 def test_run_1k_steps(observation_keys, benchmark):
-    env = nle.env.base.NLE(savedir=None, observation_keys=observation_keys)
+    env = gym.make('NetHack-v0', savedir=None, observation_keys=observation_keys)
     seeds = [123456]
     steps = 1000
 
@@ -46,4 +46,4 @@ def test_run_1k_steps(observation_keys, benchmark):
                 seed()
                 env.reset()
 
-    benchmark.pedantic(play_1k_steps, setup=seed, rounds=1000, warmup_rounds=10)
+    benchmark.pedantic(play_1k_steps, setup=seed, rounds=100, warmup_rounds=10)

--- a/nle/tests/test_profile.py
+++ b/nle/tests/test_profile.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import pytest
+
+import nle
+from nle.nethack import OBSERVATION_DESC
+import gym
+import numpy as np
+
+ACTIONS = [nle.nethack.MiscAction.MORE]
+ACTIONS += list(nle.nethack.CompassDirection)
+ACTIONS += list(nle.nethack.CompassDirectionLonger)
+
+@pytest.mark.benchmark(min_rounds=30, disable_gc=True, warmup=False)
+def test_1k_steps_performance(benchmark):
+    obs = [o for o in OBSERVATION_DESC.keys() if o not in ['screen_descriptions']]
+    env = nle.env.base.NLE(observation_keys=obs  )
+
+    steps = 1000
+    actions = np.random.choice(len(env._actions), size=steps)
+
+    def play_1k_steps():
+        env.reset()
+        for a in actions:
+            _, _, done, _ = env.step(a)
+            if done:
+                env.reset()
+
+    benchmark(play_1k_steps)

--- a/nle/tests/test_profile.py
+++ b/nle/tests/test_profile.py
@@ -14,27 +14,36 @@ BASE_KEYS = ['glyphs', 'message', 'blstats']
 MAPPED_GLYPH = ['chars', 'colors', 'specials']
 INV_GLYPH = ['inv_glyphs', 'inv_strs', 'inv_letters', 'inv_oclasses']
 SCREEN_DESC = ['screen_descriptions']
+TTY = ['tty_chars', 'tty_colors', 'tty_cursor']
 
-OBS_KEYS = [
-    BASE_KEYS,
-    BASE_KEYS + MAPPED_GLYPH,
-    BASE_KEYS + MAPPED_GLYPH + INV_GLYPH,
-    BASE_KEYS + MAPPED_GLYPH + INV_GLYPH + SCREEN_DESC
-]
+EXPERIMENTS= {
+    '(1): glyphs/msg/blstats': BASE_KEYS,
+    '(2): (1)... + char/col/spec': BASE_KEYS + MAPPED_GLYPH,
+    '(3): (2)... + inv_*': BASE_KEYS + MAPPED_GLYPH + INV_GLYPH,
+    '(4): (3)... + screen_desc':BASE_KEYS + MAPPED_GLYPH + INV_GLYPH + SCREEN_DESC
+}
 
-@pytest.mark.parametrize('observation_keys', OBS_KEYS)
-@pytest.mark.benchmark(min_rounds=30, disable_gc=True, warmup=False)
-def test_1k_steps_performance(observation_keys, benchmark):
+@pytest.mark.parametrize('observation_keys', EXPERIMENTS.values(), ids=EXPERIMENTS.keys())
+@pytest.mark.benchmark(disable_gc=True, warmup=False)
+def test_run_1k_steps( observation_keys, benchmark):
     env = nle.env.base.NLE(observation_keys=observation_keys)
-
+    seeds = [123456]
     steps = 1000
+
+    np.random.seed(seeds[0])
     actions = np.random.choice(len(env._actions), size=steps)
+
+    def seed():
+        seeds[0] += 1
+        env.seed(seeds[0], 2 * seeds[0])
+
 
     def play_1k_steps():
         env.reset()
         for a in actions:
             _, _, done, _ = env.step(a)
             if done:
+                seed()
                 env.reset()
 
-    benchmark(play_1k_steps)
+    benchmark.pedantic(play_1k_steps, setup=seed, rounds=1000, warmup_rounds=10)

--- a/nle/tests/test_profile.py
+++ b/nle/tests/test_profile.py
@@ -10,23 +10,26 @@ import gym
 import numpy as np
 
 
-BASE_KEYS = ['glyphs', 'message', 'blstats']
-MAPPED_GLYPH = ['chars', 'colors', 'specials']
-INV_GLYPH = ['inv_glyphs', 'inv_strs', 'inv_letters', 'inv_oclasses']
-SCREEN_DESC = ['screen_descriptions']
-TTY = ['tty_chars', 'tty_colors', 'tty_cursor']
+BASE_KEYS = ["glyphs", "message", "blstats"]
+MAPPED_GLYPH = ["chars", "colors", "specials"]
+INV_GLYPH = ["inv_glyphs", "inv_strs", "inv_letters", "inv_oclasses"]
+SCREEN_DESC = ["screen_descriptions"]
+TTY = ["tty_chars", "tty_colors", "tty_cursor"]
 
-EXPERIMENTS= {
-    '(1): glyphs/msg/blstats': BASE_KEYS,
-    '(2): (1)... + char/col/spec': BASE_KEYS + MAPPED_GLYPH,
-    '(3): (2)... + inv_*': BASE_KEYS + MAPPED_GLYPH + INV_GLYPH,
-    '(4): (3)... + screen_desc':BASE_KEYS + MAPPED_GLYPH + INV_GLYPH + SCREEN_DESC
+EXPERIMENTS = {
+    "(1): glyphs/msg/blstats": BASE_KEYS,
+    "(2): (1)... + char/col/spec": BASE_KEYS + MAPPED_GLYPH,
+    "(3): (2)... + inv_*": BASE_KEYS + MAPPED_GLYPH + INV_GLYPH,
+    "(4): (3)... + screen_desc": BASE_KEYS + MAPPED_GLYPH + INV_GLYPH + SCREEN_DESC,
 }
 
-@pytest.mark.parametrize('observation_keys', EXPERIMENTS.values(), ids=EXPERIMENTS.keys())
+
+@pytest.mark.parametrize(
+    "observation_keys", EXPERIMENTS.values(), ids=EXPERIMENTS.keys()
+)
 @pytest.mark.benchmark(disable_gc=True, warmup=False)
-def test_run_1k_steps( observation_keys, benchmark):
-    env = nle.env.base.NLE(observation_keys=observation_keys)
+def test_run_1k_steps(observation_keys, benchmark):
+    env = nle.env.base.NLE(savedir=None, observation_keys=observation_keys)
     seeds = [123456]
     steps = 1000
 
@@ -36,7 +39,6 @@ def test_run_1k_steps( observation_keys, benchmark):
     def seed():
         seeds[0] += 1
         env.seed(seeds[0], 2 * seeds[0])
-
 
     def play_1k_steps():
         env.reset()

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ extras_deps = {
         "flake8>=3.7",
         "flake8-bugbear>=20.1",
         "pytest>=5.3",
+        "pytest-benchmark>=3.1.0",
         "sphinx>=2.4.4",
         "sphinx-rtd-theme==0.4.3",
     ],


### PR DESCRIPTION
## TL:DR;
This PR involves 2 fixes. 
* 1st a fixup to `check_nethack_speed` to ensure it runs. Sadly as its not hooked into any automated tests I think it just got a bit out of sync with the API.
* 2nd is an introduction of a profiling test using pytest-benchmark. I think this set up will allow us to effectively and (relatively) reliably measure SPS for our code changes. The output of such a pytest-benchmark is very also informative - note the OPS column gives us the mean kilo-steps-per-second.  

## Example Output

<img width="1789" alt="master" src="https://user-images.githubusercontent.com/6815729/99189750-a1cc6900-275a-11eb-9a6a-1d45f616bd26.png">



## Why use the benchmark instead of the former script**? 

Well it seemed to me that the former script didn't really measure the steps per second of a single environment, rather the maximum throughput one could get running all the environments in suprocesses and putting the number of steps in a shared queue (which could be still useful!).

To illustrate my point consider the following screenshot, in which you choose 1, 2, 5, and (default) 10 environments to use. Clearly there's an communication overhead that becomes the dominant factor at 50k steps per second, which is misleading given each of the 10 environments can reach about 10k steps a second.

<img width="542" alt="Screenshot 2020-11-15 at 15 46 03" src="https://user-images.githubusercontent.com/6815729/99189754-aabd3a80-275a-11eb-97d3-740a426a1146.png">

As a result I propose using the pytest-benchmark to run performance tests, and perhaps rename `check_nethack_speed` to something more descriptive? I'm open to suggestions.




