### PR TITLE
Improve performance 

### DIFF
--- a/win/rl/winrl.cc
+++ b/win/rl/winrl.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <stdio.h>
 #include <string>
+#include <cstring>
 #include <unistd.h>
 #include <vector>
 
@@ -414,14 +415,8 @@ NetHackRL::fill_obs(nle_obs *obs)
     if (obs->screen_descriptions) {
         int i = 0;
         for (const std::string &screen_description : screen_descriptions_) {
-            int j = 0;
-            for (int len = screen_description.length();
-                 j < len && j < NLE_SCREEN_DESCRIPTION_LENGTH; ++j) {
-                obs->screen_descriptions[i++] = screen_description[j];
-            }
-            for (; j < NLE_SCREEN_DESCRIPTION_LENGTH; ++j) {
-                obs->screen_descriptions[i++] = 0;
-            }
+            strncpy((char * ) obs->screen_descriptions + i, screen_description.c_str(), NLE_SCREEN_DESCRIPTION_LENGTH);
+            i += NLE_SCREEN_DESCRIPTION_LENGTH;
         }
     }
 }
@@ -885,7 +880,9 @@ NetHackRL::rl_print_glyph(winid wid, XCHAR_P x, XCHAR_P y, int glyph,
     if (wid == WIN_MAP) {
         instance->store_glyph(x, y, glyph);
         instance->store_mapped_glyph(ch, color, special, x, y);
-        instance->store_screen_description(x, y, glyph);
+        if (nle_get_obs()->screen_descriptions) {
+            instance->store_screen_description(x, y, glyph);
+        }
     } else {
         DEBUG_API("Window id is " << wid << ". This shouldn't happen."
                                   << std::endl);


### PR DESCRIPTION
# TL:DR 

Having profiled the code using the tests presented in PR #130 , it became clear the performance of the screen descriptions was adding some quite considerable hits, not just to its own observation keys but everyone.  Below are two commits, offering two solutions - I prefer the last which is the fastest.

###  Master


<img width="1789" alt="master" src="https://user-images.githubusercontent.com/6815729/99190058-56b35580-275c-11eb-9756-5f0b45c016da.png">

### Commit [252bwd19](https://github.com/facebookresearch/nle/commit/252bd19f8121442717645804f3bd268a0faeb197):

This commit does two things: First it only gets screen_desriptions from nethack if they are asked for, and secondly, it uses `strncpy` instead of a for loop. Each of these changes is pretty significant, the former adding 2-3ksps to everyone's performance and the latter adding the same just to screen_descriptions obskey environments.  The price paid is a rather ugly access of the global observation object in the function, but the performance improvement is significant.

<img width="1789" alt="strncpy" src="https://user-images.githubusercontent.com/6815729/99190066-60d55400-275c-11eb-96c4-46d32b8ab794.png">

###  Commit [a1793a6](https://github.com/facebookresearch/nle/commit/a1793a6ea0e6e2be8b95fc500828327187ffe24f) 

This commit replaces the array of std::strings with one big char array that we strncpy to and then memcopy out. The use of these built ins adds a lot of speed, but we also need to only fill the array with 0's when necessary, so there is another global observation object check.

<img width="1789" alt="memcopy" src="https://user-images.githubusercontent.com/6815729/99190148-d4776100-275c-11eb-9a77-1016b81d56f4.png">


There is one final thing we can do to improve performance (at the cost of the sensible engineering practice) - we could write the string descriptions straight into the observation. It feels kind of gross, but its worth remembering that we more or less will be doing the same stuff with the tty observations.

