### PR TITLE
[WIP] Libnethack shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 
 message(STATUS "Building nle backend version: ${NLE_VERSION}")
 
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # We use this to decide where the root of the nle/ package is. Normally it
@@ -99,9 +100,11 @@ target_link_directories(nethack PUBLIC /usr/local/lib)
 target_link_libraries(nethack PUBLIC m fcontext bz2)
 
 # dlopen wrapper library
-add_library(nethackdl STATIC "sys/unix/nledl.c")
+add_library(nethackdl STATIC "sys/unix/nledl.c" "sys/unix/nleshared.cc")
 target_include_directories(nethackdl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(nethackdl PUBLIC dl)
+
+#set_target_properties(nethackdl PROPERTIES CMAKE_CXX_STANDARD 17)
 
 # rlmain C++ (test) binary
 add_executable(rlmain "sys/unix/rlmain.cc")

--- a/include/nledl.h
+++ b/include/nledl.h
@@ -10,15 +10,9 @@
 #include "nleobs.h"
 
 /* TODO: Don't call this nle_ctx_t as well. */
-typedef struct nledl_ctx {
-    char dlpath[1024];
-    void *dlhandle;
-    void *nle_ctx;
-    void *(*step)(void *, nle_obs *);
-    FILE *ttyrec;
-} nle_ctx_t;
+typedef struct nledl_ctx nle_ctx_t;
 
-nle_ctx_t *nle_start(const char *, nle_obs *, FILE *, nle_seeds_init_t *);
+nle_ctx_t *nle_start(const char *, nle_obs *, FILE *, nle_seeds_init_t *, int shared);
 nle_ctx_t *nle_step(nle_ctx_t *, nle_obs *);
 
 void nle_reset(nle_ctx_t *, nle_obs *, FILE *, nle_seeds_init_t *);
@@ -26,5 +20,7 @@ void nle_end(nle_ctx_t *);
 
 void nle_set_seed(nle_ctx_t *, unsigned long, unsigned long, char);
 void nle_get_seed(nle_ctx_t *, unsigned long *, unsigned long *, char *);
+
+int nle_supports_shared(void);
 
 #endif /* NLEDL_H */

--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -118,12 +118,10 @@ nle_reset(nle_ctx_t *nledl, nle_obs *obs, FILE *ttyrec,
           nle_seeds_init_t *seed_init)
 {
     if (nledl->shared) {
-      printf("doing reset\n");
       nledl->end(nledl->nle_ctx);
       nleshared_reset(nledl->shared);
       if (ttyrec)
           nledl->ttyrec = ttyrec;
-      printf("kay\n");
       nledl->nle_ctx = nledl->start(obs, ttyrec, seed_init);
     } else {
       nledl_close(nledl);

--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -48,8 +48,6 @@ nledl_init(nle_ctx_t *nledl, nle_obs *obs, nle_seeds_init_t *seed_init, int shar
   if (shared) {
 #ifdef HASSHARED
     nledl->shared = nleshared_open(nledl->dlpath);
-    nledl->start = nleshared_sym(nledl->shared, "nle_start");
-    nledl->step = nleshared_sym(nledl->shared, "nle_step");
 #else
     fprintf(stderr, "Shared mode not supported on this system!\n");
     exit(EXIT_FAILURE);
@@ -120,10 +118,12 @@ nle_reset(nle_ctx_t *nledl, nle_obs *obs, FILE *ttyrec,
           nle_seeds_init_t *seed_init)
 {
     if (nledl->shared) {
+      printf("doing reset\n");
       nledl->end(nledl->nle_ctx);
       nleshared_reset(nledl->shared);
       if (ttyrec)
           nledl->ttyrec = ttyrec;
+      printf("kay\n");
       nledl->nle_ctx = nledl->start(obs, ttyrec, seed_init);
     } else {
       nledl_close(nledl);

--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -8,12 +8,12 @@
 
 #if defined(__linux__) && defined(__x86_64__)
 #define HASSHARED
+#endif
 
 void* nleshared_open(const char *dlpath);
 void nleshared_close(void* handle);
 void nleshared_reset(void* handle);
 void* nleshared_sym(void* handle, const char* symname);
-#endif
 
 typedef struct nledl_ctx {
     void* shared;

--- a/sys/unix/nleshared.cc
+++ b/sys/unix/nleshared.cc
@@ -576,12 +576,15 @@ int chdir(const char* path) {
   });
   return 0;
 }
-int rename(const char*, const char*) {
-  errno = EACCES;
+int rename(const char* src, const char* dst) {
+  errno = ENOENT;
+  return -1;
+}
+int unlink(const char* path) {
+  errno = ENOENT;
   return -1;
 }
 int creat(const char* path, int) {
-  errno = EPERM;
   //printf("creat %s\n", path);
   return memfd_create(path, 0);
 }
@@ -644,7 +647,6 @@ struct NLEShared {
     ovr("abort", rep::abort);
     ovr("popen", rep::popen);
     ovr("fork", rep::fork);
-    ovr("exit", rep::exit);
     ovr("sleep", rep::sleep);
     ovr("execl", rep::execl);
 
@@ -653,6 +655,8 @@ struct NLEShared {
     ovr("rename", rep::rename);
     ovr("creat", rep::creat);
     ovr("open", rep::open);
+    ovr("rename", rep::rename);
+    ovr("unlink", rep::unlink);
     ovr("fopen", rep::fopen);
     ovr("setuid", rep::setuid);
 //    ovr("getpwnam", rep::getpwnam);

--- a/sys/unix/nleshared.cc
+++ b/sys/unix/nleshared.cc
@@ -1,4 +1,6 @@
 
+#if defined(__linux__) && defined(__x86_64__)
+
 #include <elf.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -662,3 +664,21 @@ extern "C" void* nleshared_sym(void* handle, const char* symname) {
   return (void*)env->instance.loader.symbol<void()>(symname).resolve(env->instance);
 }
 
+#else
+
+#include <cstdlib>
+#include <stdexcept>
+
+extern "C" void* nleshared_open(const char *dlpath) {
+  throw std::runtime_error("NLE shared not supported on this platform");
+}
+extern "C" void nleshared_close(void* handle) {
+  std::abort();
+}
+extern "C" void nleshared_reset(void* handle) {
+  std::abort();
+}
+extern "C" void* nleshared_sym(void* handle, const char* symname) {
+  std::abort();
+}
+#endif

--- a/sys/unix/nleshared.cc
+++ b/sys/unix/nleshared.cc
@@ -1,0 +1,576 @@
+
+#include <elf.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <dlfcn.h>
+
+#include <string_view>
+#include <string>
+#include <cstdio>
+#include <stdexcept>
+#include <system_error>
+#include <vector>
+#include <cstddef>
+#include <cstring>
+#include <unordered_map>
+
+struct NHLoader {
+  std::vector<std::byte> data;
+  Elf64_Ehdr* hdr;
+  size_t baseaddr;
+  size_t endaddr;
+  size_t size;
+  int fd;
+  void* ptr;
+  std::byte* sharedbase;
+  std::vector<std::pair<uint64_t, uint64_t>> relocations;
+  std::vector<std::pair<uint64_t, uint64_t>> writableRelocations;
+  size_t initfunc;
+  size_t finifunc;
+  size_t initarray;
+  size_t initarraysz;
+  size_t finiarray;
+  size_t finiarraysz;
+  NHLoader(std::string libPath, const std::unordered_map<std::string, void*>& overrides) {
+    FILE* f = fopen(libPath.c_str(), "rb");
+    if (!f) {
+      throw std::runtime_error("Failed to open '" + libPath + "' for reading");
+    }
+    fseek(f, 0, SEEK_END);
+    data.resize(ftell(f));
+    fseek(f, 0, SEEK_SET);
+    fread(data.data(), data.size(), 1, f);
+    fclose(f);
+
+    hdr = (Elf64_Ehdr*)data.data();
+    boundsCheck(hdr);
+
+    baseaddr = ~0;
+    endaddr = 0;
+    size = 0;
+
+    forPh([&](Elf64_Phdr* ph) {;
+
+      printf("ph type %#x at [%p, %p) (fs %#x)\n", ph->p_type, (void*)ph->p_vaddr, (void*)(ph->p_vaddr + ph->p_memsz), ph->p_filesz);
+
+      if (ph->p_type == PT_LOAD) {
+        baseaddr = std::min(baseaddr, (size_t)ph->p_vaddr);
+        endaddr = std::max(endaddr, (size_t)(ph->p_vaddr + ph->p_memsz));
+      }
+
+    });
+
+    if (baseaddr == (size_t)~0) {
+      throw std::runtime_error("No loadable program segments found");
+    }
+
+    size = endaddr - baseaddr;
+
+    printf("memsize is %ldM\n", size / 1024 / 1024);
+
+    fd = memfd_create("nethack", 0);
+    if (fd < 0) {
+      throw std::system_error(errno, std::system_category(), "memfd_create");
+    }
+    if (ftruncate(fd, size)) {
+      throw std::system_error(errno, std::system_category(), "ftruncate");
+    }
+
+    ptr = ::mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (!ptr || ptr == MAP_FAILED) {
+      throw std::runtime_error("Failed to allocate memory for binary image");
+    }
+
+    std::byte* base = (std::byte*)ptr - baseaddr;
+    sharedbase = base;
+
+    forPh([&](Elf64_Phdr* ph) {
+      if (ph->p_type == PT_LOAD) {
+        std::memcpy(base + ph->p_vaddr, data.data() + ph->p_offset, ph->p_filesz);
+      }
+    });
+    link(overrides);
+    mprotect(ptr, size, PROT_READ);
+  }
+
+  void boundsCheck(std::byte* begin, std::byte* end) {
+    if (begin < data.data() || end > data.data() + data.size()) {
+      throw std::runtime_error("Out of bounds access parsing ELF (corrupt file?)");
+    }
+  }
+
+  template<typename T>
+  void boundsCheck(T* ptr) {
+    std::byte* begin = (std::byte*)ptr;
+    std::byte* end = begin + sizeof(T);
+    boundsCheck(begin, end);
+  }
+
+  template<typename F>
+  void forPh(F&& f) {
+    auto phoff = hdr->e_phoff;
+    for (size_t i = 0; i != hdr->e_phnum; ++i) {
+      Elf64_Phdr* ph = (Elf64_Phdr*)(data.data() + phoff);
+      boundsCheck(ph);
+
+      f(ph);
+
+      phoff += hdr->e_phentsize;
+    }
+  }
+
+  template<typename T>
+  struct Function;
+  template<typename R, typename... Args>
+  struct Function<R(Args...)> {
+    size_t offset;
+
+    template<typename Instance>
+    R operator()(Instance& i, Args... args) {
+      return i.call(*this, args...);
+    }
+  };
+
+  struct Instance {
+    NHLoader& loader;
+    void* ptr;
+    std::byte* base;
+    Instance(NHLoader& loader) : loader(loader) {}
+    Instance(const Instance&) = delete;
+    Instance(Instance&& n) : loader(n.loader) {
+      ptr = std::exchange(n.ptr, nullptr);
+      base = std::exchange(n.base, nullptr);
+    }
+    ~Instance() {
+      if (ptr) {
+        loader.free(*this);
+      }
+    }
+    void reset() {
+      loader.reset(*this);
+    }
+    void init() {
+      if (loader.initfunc) {
+        ((void(*)())(base + loader.initfunc))();
+      }
+      if (loader.initarray) {
+        for (size_t i = 0; i != loader.initarraysz / sizeof(void*); ++i) {
+          ((void(*)())((void**)(base + loader.initarray))[i])();
+        }
+      }
+    }
+    void fini() {
+      if (loader.finiarray) {
+        for (size_t i = 0; i != loader.finiarraysz / sizeof(void*); ++i) {
+          ((void(*)())((void**)(base + loader.finiarray))[i])();
+        }
+      }
+      if (loader.finifunc) {
+        ((void(*)())(base + loader.finifunc))();
+      }
+    }
+    template<typename Sig, typename... Args>
+    auto call(Function<Sig> func, Args&&... args) {
+      return ((Sig*)(void*)(base + func.offset))(std::forward<Args>(args)...);
+    }
+  };
+
+  void link(const std::unordered_map<std::string, void*>& overrides) {
+
+    std::byte* base = sharedbase;
+
+    printf("Loaded at base %p\n", base);
+
+    std::byte* symtab = nullptr;
+    const char* strtab = nullptr;
+
+    size_t relasz = 0;
+    size_t relaent = 0;
+    size_t pltrelsz = 0;
+    size_t syment = 0;
+
+    forPh([&](Elf64_Phdr* ph) {
+
+      if (ph->p_type == PT_DYNAMIC) {
+        Elf64_Dyn* dyn = (Elf64_Dyn*)(data.data() + ph->p_offset);
+        Elf64_Dyn* dynEnd = (Elf64_Dyn*)(data.data() + ph->p_offset + ph->p_filesz);
+        while (dyn < dynEnd) {
+          boundsCheck(dyn);
+
+          switch (dyn->d_tag) {
+          case DT_SYMTAB:
+            symtab = base + dyn->d_un.d_ptr;
+            break;
+          case DT_STRTAB:
+            strtab = (const char*)(base + dyn->d_un.d_ptr);
+            break;
+          case DT_RELASZ:
+            relasz = dyn->d_un.d_val;
+            break;
+          case DT_RELAENT:
+            relaent = dyn->d_un.d_val;
+            break;
+          case DT_SYMENT:
+            syment = dyn->d_un.d_val;
+            break;
+          case DT_PLTRELSZ:
+            pltrelsz = dyn->d_un.d_val;
+            break;
+          }
+
+          ++dyn;
+        }
+      }
+    });
+
+    struct Address {
+      bool isRelative;
+      uint64_t value;
+    };
+
+    std::unordered_map<size_t, std::byte*> symbolAddressMap;
+
+    auto symbolAddress = [&](size_t index) {
+      Elf64_Sym* sym = (Elf64_Sym*)(symtab + syment * index);
+      if (sym->st_value) {
+        return Address{true, sym->st_value};
+      }
+      auto i = symbolAddressMap.emplace(index, nullptr);
+      auto& r = i.first->second;
+      if (!i.second) {
+        return Address{false, (uint64_t)r};
+      }
+      std::string name = strtab + sym->st_name;
+      printf("Looking up symbol %s\n", name.c_str());
+
+      auto oi = overrides.find(name);
+      if (oi != overrides.end()) {
+        r = (std::byte*)oi->second;
+      } else {
+        r = (std::byte*)dlsym(RTLD_DEFAULT, name.c_str());
+        if (!r && ELF64_ST_BIND(sym->st_info) != STB_WEAK) {
+          throw std::runtime_error("Symbol " + name + " not found");
+        }
+      }
+      return Address{false, (uint64_t)r};
+    };
+
+    auto copy64 = [&](std::byte* dst, Address addr) {
+      if (addr.isRelative) {
+        relocations.emplace_back(dst - base, addr.value);
+      }
+      std::byte* value = addr.isRelative ? base + addr.value : (std::byte*)addr.value;
+      std::memcpy(dst, &value, sizeof(value));
+    };
+
+    auto doRela = [&](Elf64_Rela* rela) {
+      auto type = ELF64_R_TYPE(rela->r_info);
+      auto sym = ELF64_R_SYM(rela->r_info);
+      std::byte* address = base + rela->r_offset;
+      auto addend = rela->r_addend;
+      switch (type) {
+      case R_X86_64_JUMP_SLOT:
+      case R_X86_64_GLOB_DAT:
+        copy64(address, symbolAddress(sym));
+        break;
+      case R_X86_64_RELATIVE:
+        copy64(address, Address{true, (uint64_t)addend});
+        break;
+      case R_X86_64_64: {
+        auto a = symbolAddress(sym);
+        a.value += addend;
+        copy64(address, a);
+        break;
+      }
+      default:
+        throw std::runtime_error("Unsupported relocation type " + std::to_string(type));
+      }
+    };
+
+    initfunc = 0;
+    finifunc = 0;
+    initarray = 0;
+    initarraysz = 0;
+    finiarray = 0;
+    finiarraysz = 0;
+
+    forPh([&](Elf64_Phdr* ph) {
+
+      if (ph->p_type == PT_DYNAMIC) {
+        Elf64_Dyn* dyn = (Elf64_Dyn*)(data.data() + ph->p_offset);
+        Elf64_Dyn* dynEnd = (Elf64_Dyn*)(data.data() + ph->p_offset + ph->p_filesz);
+        while (dyn < dynEnd) {
+          boundsCheck(dyn);
+
+          switch (dyn->d_tag) {
+          case DT_RELA: {
+            if (relasz > 0 && relaent > 0) {
+              //printf("dyn->d_un.d_ptr is %#x\n", dyn->d_un.d_ptr);
+              for (size_t i = 0; i != relasz / relaent; ++i) {
+                Elf64_Rela* rela = (Elf64_Rela*)(base + dyn->d_un.d_ptr + relaent * i);
+                doRela(rela);
+
+                Elf64_Sym* sym = (Elf64_Sym*)(symtab + syment * ELF64_R_SYM(rela->r_info));
+                if (sym->st_value == 0) {
+                  //printf("relocation type %#lx %#x\n", ELF64_R_TYPE(rela->r_info), ELF64_R_SYM(rela->r_info));
+                  //printf("sym %s val %#lx\n", strtab + sym->st_name, sym->st_value);
+                }
+              }
+            }
+            break;
+          }
+          case DT_REL:
+            printf("has rel\n");
+            break;
+          case DT_PLTREL: {
+            if (dyn->d_un.d_val == DT_RELA) {
+              printf("plt rela\n");
+            } else {
+              throw std::runtime_error("Unsupported value for DT_PLTREL");
+            }
+            break;
+          }
+          case DT_JMPREL: {
+            if (relasz > 0 && relaent > 0) {
+              //printf("dyn->d_un.d_ptr is %#x\n", dyn->d_un.d_ptr);
+              for (size_t i = 0; i != pltrelsz / relaent; ++i) {
+                Elf64_Rela* rela = (Elf64_Rela*)(base + dyn->d_un.d_ptr + relaent * i);
+                doRela(rela);
+                Elf64_Sym* sym = (Elf64_Sym*)(symtab + syment * ELF64_R_SYM(rela->r_info));
+                if (sym->st_value == 0) {
+                  //printf("relocation type %#lx %#x\n", ELF64_R_TYPE(rela->r_info), ELF64_R_SYM(rela->r_info));
+                  //printf("sym %s val %#lx\n", strtab + sym->st_name, sym->st_value);
+                }
+              }
+            }
+            break;
+          }
+          case DT_INIT:
+            initfunc = dyn->d_un.d_ptr;
+            break;
+          case DT_FINI:
+            finifunc = dyn->d_un.d_ptr;
+            break;
+          case DT_INIT_ARRAY:
+            initarray = dyn->d_un.d_ptr;
+            break;
+          case DT_INIT_ARRAYSZ:
+            initarraysz = dyn->d_un.d_val;
+            break;
+          case DT_FINI_ARRAY:
+            finiarray = dyn->d_un.d_ptr;
+            break;
+          case DT_FINI_ARRAYSZ:
+            finiarraysz = dyn->d_un.d_val;
+            break;
+          }
+
+          ++dyn;
+        }
+      }
+    });
+
+    forPh([&](Elf64_Phdr* ph) {
+      if (ph->p_type == PT_LOAD && (ph->p_flags & PF_W)) {
+        uint64_t begin = ph->p_vaddr;
+        uint64_t end = ph->p_vaddr + ph->p_memsz;
+        for (auto [dst, offset] : relocations) {
+          if (dst >= begin && dst < end) {
+            writableRelocations.emplace_back(dst, offset);
+          }
+        }
+      }
+    });
+
+  }
+
+  template<typename Sig>
+  Function<Sig> symbol(std::string name) {
+    uint64_t offset = hdr->e_shoff;
+    size_t n = hdr->e_shnum;
+//    size_t strtab = 0;
+//    for (size_t i = 0; i != n; ++i) {
+//      Elf64_Shdr* shdr = (Elf64_Shdr*)(data.data() + offset);
+//      boundsCheck(shdr);
+
+//      if (shdr->sh_type == SHT_STRTAB) {
+//        strtab = shdr->sh_offset;
+//        printf("strtab is %d bytes\n", shdr->sh_size);
+//      }
+
+//      offset += hdr->e_shentsize;
+//    }
+//    if (!strtab) {
+//      throw std::runtime_error("strtab section not found");
+//    }
+    offset = hdr->e_shoff;
+    for (size_t i = 0; i != n; ++i) {
+      Elf64_Shdr* shdr = (Elf64_Shdr*)(data.data() + offset);
+      boundsCheck(shdr);
+
+      if (shdr->sh_type == SHT_SYMTAB) {
+
+        size_t strtab = ((Elf64_Shdr*)(data.data() + hdr->e_shoff + hdr->e_shentsize * shdr->sh_link))->sh_offset;
+
+        auto begin = shdr->sh_offset;
+        auto end = begin + shdr->sh_size;
+        for (auto i = begin; i < end; i += shdr->sh_entsize) {
+          Elf64_Sym* sym = (Elf64_Sym*)(data.data() + i);
+          boundsCheck(sym);
+
+          //printf("sym->st_name is %d\n", sym->st_name);
+
+          std::string_view sname = (const char*)(data.data() + strtab + sym->st_name);
+          if (sname == name) {
+            return {sym->st_value};
+            //printf("found symbol %s\n", std::string(sname).c_str());
+          }
+        }
+      }
+
+      offset += hdr->e_shentsize;
+    }
+
+    throw std::runtime_error("Could not find symbol " + name);
+  }
+
+  Instance fork() {
+
+    void* ptr = ::mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+    if (!ptr || ptr == MAP_FAILED) {
+      throw std::runtime_error("Failed to allocate memory for binary image");
+    }
+
+    std::byte* base = (std::byte*)ptr - baseaddr;
+
+    std::unordered_map<size_t, bool> pagesTouched;
+
+    printf("There are %d relocations\n", relocations.size());
+
+    for (auto& v : relocations) {
+      std::byte* dst = base + v.first;
+      std::byte* value = base + v.second;
+      pagesTouched[(size_t)dst / 0x1000] = true;
+
+      std::memcpy(dst, &value, sizeof(value));
+    }
+
+    forPh([&](Elf64_Phdr* ph) {
+      if (ph->p_type == PT_LOAD) {
+        int flags = 0;
+        if (ph->p_flags & PF_R) {
+          flags |= PROT_READ;
+        }
+        if (ph->p_flags & PF_W) {
+          flags |= PROT_WRITE;
+        }
+        if (ph->p_flags & PF_X) {
+          flags |= PROT_EXEC;
+        }
+        mprotect(base + ph->p_vaddr, ph->p_memsz, flags);
+      }
+    });
+
+    printf("Touched %d/%d pages\n", pagesTouched.size(), size / 0x1000);
+
+    int nWritableTouched = 0;
+    int nWritableTotal = 0;
+
+    forPh([&](Elf64_Phdr* ph) {
+      if (ph->p_type == PT_LOAD && (ph->p_flags & PF_W)) {
+        for (std::byte* p = base + ph->p_vaddr; p < base + ph->p_vaddr + ph->p_memsz; p += 0x1000) {
+          if (pagesTouched[(size_t)p / 0x1000]) {
+            ++nWritableTouched;
+          }
+          ++nWritableTotal;
+        }
+      }
+    });
+
+    printf("Writable touched %d/%d pages\n", nWritableTouched, nWritableTotal);
+
+    printf("success!\n");
+
+    Instance i(*this);
+    i.ptr = ptr;
+    i.base = base;
+    return i;
+  }
+
+  void reset(Instance& i) {
+    forPh([&](Elf64_Phdr* ph) {
+      if (ph->p_type == PT_LOAD && (ph->p_flags & PF_W)) {
+        std::memcpy(i.base + ph->p_vaddr, sharedbase + ph->p_vaddr, ph->p_memsz);
+      }
+    });
+    for (auto& v : writableRelocations) {
+      std::byte* dst = i.base + v.first;
+      std::byte* value = i.base + v.second;
+      std::memcpy(dst, &value, sizeof(value));
+    }
+  }
+
+  void free(Instance& i) {
+    ::munmap(i.ptr, size);
+  }
+
+};
+
+namespace rep {
+
+int has_colors() {
+  return 1;
+}
+
+int chdir(const char* path) {
+  printf("chdir %s\n", path);
+  return 0;
+}
+
+void exit(int exitcode) {
+  printf("exit %d\n", exitcode);
+  throw std::runtime_error("Exit!?");
+}
+
+}
+
+struct NLEShared {
+  std::string dlpath;
+  NHLoader loader;
+
+  NLEShared(std::string dlpath) : dlpath(dlpath), loader(dlpath, makeOverrides()) {}
+
+  std::unordered_map<std::string, void*> makeOverrides() {
+    std::unordered_map<std::string, void*> overrides;
+
+    auto ovr = [&](std::string name, auto* f) {
+      overrides[name] = (void*)f;
+    };
+
+    ovr("has_colors", rep::has_colors);
+
+    ovr("chdir", rep::chdir);
+    ovr("exit", rep::exit);
+
+    return overrides;
+  }
+
+};
+
+extern "C" void* nleshared_open(const char *dlpath) {
+  static NLEShared shared(dlpath);
+  if (shared.dlpath != dlpath) {
+    throw std::runtime_error("nleshared only supports one dlpath at the moment");
+  }
+}
+extern "C" void nleshared_close(void* handle) {
+
+}
+extern "C" void nleshared_reset(void* handle) {
+
+}
+extern "C" void* nleshared_sym(void* handle, const char* symname) {
+
+}
+

--- a/sys/unix/rlmain.cc
+++ b/sys/unix/rlmain.cc
@@ -115,7 +115,7 @@ main(int argc, char **argv)
         fopen("nle.ttyrec.bz2", "a"), fclose);
 
     ScopedTC tc;
-    nle_ctx_t *nle = nle_start("libnethack.so", &obs, ttyrec.get(), nullptr);
+    nle_ctx_t *nle = nle_start("libnethack.so", &obs, ttyrec.get(), nullptr, nle_supports_shared());
     if (argc > 1 && argv[1][0] == 'r') {
         randgame(nle, &obs, 3);
     } else {

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -60,9 +60,10 @@ checked_conversion(py::handle h, const std::vector<ssize_t> &shape)
 class Nethack
 {
   public:
-    Nethack(std::string dlpath, std::string ttyrec)
+    Nethack(std::string dlpath, std::string ttyrec, bool shared)
         : dlpath_(std::move(dlpath)), obs_{},
-          ttyrec_(std::fopen(ttyrec.c_str(), "a"), std::fclose)
+          ttyrec_(std::fopen(ttyrec.c_str(), "a"), std::fclose),
+          shared_(shared)
     {
         if (!ttyrec_) {
             PyErr_SetFromErrnoWithFilename(PyExc_OSError, ttyrec.c_str());
@@ -219,7 +220,7 @@ class Nethack
         if (!nle_) {
             nle_ = nle_start(dlpath_.c_str(), &obs_,
                              ttyrec ? ttyrec : ttyrec_.get(),
-                             use_seed_init ? &seed_init_ : nullptr);
+                             use_seed_init ? &seed_init_ : nullptr, shared_);
         } else
             nle_reset(nle_, &obs_, ttyrec,
                       use_seed_init ? &seed_init_ : nullptr);
@@ -237,6 +238,7 @@ class Nethack
     bool use_seed_init = false;
     nle_ctx_t *nle_ = nullptr;
     std::unique_ptr<std::FILE, int (*)(std::FILE *)> ttyrec_;
+    bool shared_ = false;
 };
 
 PYBIND11_MODULE(_pynethack, m)
@@ -244,8 +246,8 @@ PYBIND11_MODULE(_pynethack, m)
     m.doc() = "The NetHack Learning Environment";
 
     py::class_<Nethack>(m, "Nethack")
-        .def(py::init<std::string, std::string>(), py::arg("dlpath"),
-             py::arg("ttyrec"))
+        .def(py::init<std::string, std::string, bool>(), py::arg("dlpath"),
+             py::arg("ttyrec"), py::arg("shared"))
         .def("step", &Nethack::step, py::arg("action"))
         .def("done", &Nethack::done)
         .def("reset", py::overload_cast<>(&Nethack::reset))
@@ -269,6 +271,10 @@ PYBIND11_MODULE(_pynethack, m)
         .def("set_seeds", &Nethack::set_seeds)
         .def("get_seeds", &Nethack::get_seeds)
         .def("in_normal_game", &Nethack::in_normal_game);
+
+    m.def("supports_shared", []() {
+      return nle_supports_shared();
+    });
 
     py::module mn = m.def_submodule(
         "nethack", "Collection of NetHack constants and functions");


### PR DESCRIPTION
I'm creating this draft PR as things appear to be fully functional, but there are at minimum some cleanups necessary, and some more functionality I'd like to add.

This introduces a "shared" mode to the libnethack approach. It is Linux-only, and implements manual loading of the shared object file to avoid the need to copy the library anywhere and to better isolate the environment.
It is enabled by default on Linux and will fall back to the existing (dlopen) behavior on other platforms.
I called it shared as the shared object is actually shared between instances. Yey.

Some advantages:
  - *never* creates or writes to any files on the filesystem. NetHack is tricked into using temporary files in memory when it wants to write to something. Thus it doesn't leak anything even in the event of a crash, and instances are guaranteed not to inferere with each other (not even the leaderboard is shared). chdir is also supressed.
  - Should perform better, though this remains to be tested.
    - Resets should be much faster as they now involve little more than a 130kb memcpy.
    - Copies of the library are still done in memory, but they are copy-on-write mmapped copies - this allows them to share large portions of read-only instruction data, which in turn will be shared in the instruction cache in the CPU.
  - Some functions such as fork, popen, exit will currently throw an error, but my intention is for them to just end the episode. This allows us to continue even if nethack panics or quits for some reason.
  - It will be possible to track memory resources to detect leaks or force cleanup.

