### PR TITLE
Set libtmt submodule url to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/pybind/pybind11.git
 [submodule "third_party/libtmt"]
 	path = third_party/libtmt
-	url = git@github.com:deadpixi/libtmt.git
+	url = https://github.com/deadpixi/libtmt.git


### PR DESCRIPTION
Git protocol requires ssh + auth in most cases, so it is best to pull any public submodules using https.