### PR TITLE
Rerange tty_colors to [0, 32)

### DIFF
--- a/src/nle.c
+++ b/src/nle.c
@@ -75,7 +75,9 @@ vt_char_color_extract(TMTCHAR *c)
         break;
     }
 
-    color |= (c->a.reverse << 7); // Flip sign if reverse
+    if (c->a.reverse) {
+        color += CLR_MAX;
+    }
     return color;
 }
 


### PR DESCRIPTION
tty_colors had an unusual range perhaps intended to be [-16, 16), but ended up being... something strange.
This changes it to be [0, 32).
Seeing as nothing really uses this yet, it should be safe to change.
