### PR TITLE
Fix bug in winrl getch which makes messages disappear forever

### DIFF
--- a/win/rl/winrl.cc
+++ b/win/rl/winrl.cc
@@ -424,13 +424,15 @@ NetHackRL::getch_method()
 
     /* NOT calling tty_nhgetch() but instead getting the input from
        the context switch. No stdin required. The following code is from
-       tty_nhgetch. We don't copy the conditional ttyDisplay->toplin = 2
-       as it this seems to relate to something happening with stdin. */
+       tty_nhgetch. */
+    if (WIN_MESSAGE != WIN_ERR && wins[WIN_MESSAGE])
+        wins[WIN_MESSAGE]->flags &= ~WIN_STOP;
     if (!i)
         i = '\033'; /* map NUL to ESC since nethack doesn't expect NUL */
     else if (i == EOF)
         i = '\033'; /* same for EOF */
-
+    if (ttyDisplay && ttyDisplay->toplin == 1)
+        ttyDisplay->toplin = 2;
     DEBUG_API("getch_method: action=" << i << ", xwaitingforspace="
                                       << xwaitingforspace << std::endl);
     return i;


### PR DESCRIPTION
This method replaces tty_ngetch, and does not call it as per the comment, but it leaves out some important code (ref https://github.com/facebookresearch/nle/blob/master/win/tty/wintty.c#L3486-L3538). This PR adds this code to the winrl getch.

The bug is that if you press escape on a --more-- prompt, WIN_STOP would be set (as a signal to escape from the more prompt and skip any proceeding messages), and this flag would be reset in tty_getch. Without this reset, nle proceeds to skip *every* message in the entire game from that point on, with no recovery (this means no messages are displayed, not even "it's a wall" etc).

the toplin code is part of a tty state machine  in topl.c related to multi-line messages and more prompts, and while I can't entirely figure out the consequence of removing it, I think it's safer to keep it here.