### PR TITLE
pre-commit for python3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3.8
       exclude: scripts/plotting/*
 -   repo: https://gitlab.com/pycqa/flake8
     rev: '3.7.9'


### PR DESCRIPTION
If you install `nle` using the installation guide for the developer mode, then you are running into the following pre-commit error for black. This is because the conda environment in the guide is python3.8, not python3.7.

```
RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.7'
```

Updating the `.pre-commit-config.yaml` to python3.8 solves the problem.