### PR TITLE
Eric/competition

### DIFF
--- a/nle/env/__init__.py
+++ b/nle/env/__init__.py
@@ -16,5 +16,8 @@ registration.register(id="NetHackOracle-v0", entry_point="nle.env.tasks:NetHackO
 registration.register(id="NetHackGold-v0", entry_point="nle.env.tasks:NetHackGold")
 registration.register(id="NetHackEat-v0", entry_point="nle.env.tasks:NetHackEat")
 registration.register(id="NetHackScout-v0", entry_point="nle.env.tasks:NetHackScout")
+registration.register(
+    id="NetHackChallenge-v0", entry_point="nle.env.tasks:NetHackChallenge"
+)
 
 __all__ = ["NLE", "DUNGEON_SHAPE"]

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -94,7 +94,7 @@ NLE_SPACE_ITEMS = (
     ),
     (
         "inv_strs",
-        gym.spaces.Box(low=0, high=127, **nethack.OBSERVATION_DESC["inv_strs"]),
+        gym.spaces.Box(low=0, high=255, **nethack.OBSERVATION_DESC["inv_strs"]),
     ),
     (
         "inv_letters",
@@ -122,7 +122,7 @@ NLE_SPACE_ITEMS = (
         "tty_colors",
         gym.spaces.Box(
             low=0,
-            high=32,
+            high=31,
             **nethack.OBSERVATION_DESC["tty_colors"],
         ),
     ),

--- a/nle/nethack/actions.py
+++ b/nle/nethack/actions.py
@@ -14,9 +14,22 @@ def C(c):
     return 0x1F & c
 
 
-# Missing here:
-#   Some characters for text input (e.g., +).
-# General menu handling isn't part of this either.
+class TextCharacters(enum.IntEnum):
+    PLUS = ord("+")
+    MINUS = ord("-")
+    SPACE = ord(" ")
+    APOS = ord("'")
+    QUOTE = ord('"')
+    NUM_0 = ord("0")
+    NUM_1 = ord("1")
+    NUM_2 = ord("2")
+    NUM_3 = ord("3")
+    NUM_4 = ord("4")
+    NUM_5 = ord("5")
+    NUM_6 = ord("6")
+    NUM_7 = ord("7")
+    NUM_8 = ord("8")
+    NUM_9 = ord("9")
 
 
 class CompassCardinalDirection(enum.IntEnum):
@@ -76,6 +89,12 @@ class MiscAction(enum.IntEnum):
     MORE = ord("\r")  # read the next message
 
 
+class UnsafeActions(enum.IntEnum):
+    # currently these result in an error or undesirable behaviour
+    HELP = ord("?")  # give a help message
+    PREVMSG = C("p")  # view recent game messages
+
+
 class Command(enum.IntEnum):
     EXTCMD = ord("#")  # perform an extended command
     EXTLIST = M("?")  # list all extended commands
@@ -100,7 +119,6 @@ class Command(enum.IntEnum):
     FIGHT = ord("F")  # Prefix: force fight even if you don't see a monster
     FORCE = M("f")  # force a lock
     GLANCE = ord(";")  # show what type of thing a map symbol corresponds to
-    HELP = ord("?")  # give a help message
     HISTORY = ord("V")  # show long version and game history
     INVENTORY = ord("i")  # show your inventory
     INVENTTYPE = ord("I")  # inventory specific item types
@@ -121,7 +139,6 @@ class Command(enum.IntEnum):
     PAY = ord("p")  # pay your shopping bill
     PICKUP = ord(",")  # pick up things at the current location
     PRAY = M("p")  # pray to the gods for help
-    PREVMSG = C("p")  # view recent game messages
     PUTON = ord("P")  # put on an accessory (ring, amulet, etc)
     QUAFF = ord("q")  # quaff (drink) something
     QUIT = M("q")  # exit without saving current game
@@ -132,6 +149,7 @@ class Command(enum.IntEnum):
     RIDE = M("R")  # mount or dismount a saddled steed
     RUB = M("r")  # rub a lamp or a stone
     RUSH = ord("g")  # Prefix: rush until something interesting is seen
+    RUSH2 = ord("G")  # Prefix: rush until something interesting is seen
     SAVE = ord("S")  # save the game and exit
     SEARCH = ord("s")  # search for traps and secret doors
     SEEALL = ord("*")  # show all equipment in use
@@ -163,6 +181,7 @@ ACTIONS = tuple(
     + list(MiscDirection)
     + list(MiscAction)
     + list(Command)
+    + list(TextCharacters)
 )
 
 NON_RL_ACTIONS = (
@@ -172,13 +191,11 @@ NON_RL_ACTIONS = (
     Command.EXTCMD,  # Potentially useful for some wizard actions.
     Command.EXTLIST,
     Command.GLANCE,
-    Command.HELP,
     Command.HISTORY,
     Command.KNOWN,  # Could potentially be useful.
     Command.KNOWNCLASS,  # Could potentially be useful.
     Command.OPTIONS,
     Command.OVERVIEW,  # Could potentially be useful.
-    Command.PREVMSG,  # Could potentially be useful.
     Command.TELEPORT,
     Command.QUIT,
     Command.REDRAW,
@@ -191,13 +208,15 @@ NON_RL_ACTIONS = (
 )
 
 _USEFUL_ACTIONS = list(ACTIONS)
-for action in NON_RL_ACTIONS:
+for action in NON_RL_ACTIONS + tuple(TextCharacters):
     _USEFUL_ACTIONS.remove(action)
+_USEFUL_ACTIONS.append(TextCharacters.SPACE)
 USEFUL_ACTIONS = tuple(_USEFUL_ACTIONS)
 del _USEFUL_ACTIONS
 
 _ACTIONS_DICT = {}
 for enum_class in [
+    TextCharacters,
     CompassDirection,
     CompassDirectionLonger,
     MiscDirection,

--- a/nle/scripts/ttyplay2.py
+++ b/nle/scripts/ttyplay2.py
@@ -1,0 +1,6 @@
+from nle.nethack.actions import _ACTIONS_DICT
+import nle.scripts.ttyplay as ttyplay
+
+if __name__ == "__main__":
+    ttyplay.ACTIONS = _ACTIONS_DICT
+    ttyplay.main()

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -3351,6 +3351,26 @@ int final;
     en_win = WIN_ERR;
 }
 
+int nle_dosave() {
+    pline("You get the feeling there's only one way to save yourself..."); 
+    return 1;
+}
+
+int nle_done2() {
+    pline("You can't quit now, you're having so much fun!"); 
+    return 1;
+}
+
+int nle_doset() {
+    pline("The options are already set perfectly for you!"); 
+    return 1;
+}
+
+int nle_noop() {
+    pline("Noop");
+    return 1;
+}
+
 /* ordered by command name */
 struct ext_func_tab extcmdlist[] = {
     { '#', "#", "perform an extended command",
@@ -3391,7 +3411,7 @@ struct ext_func_tab extcmdlist[] = {
     { '\0', "herecmdmenu", "show menu of commands you can do here",
             doherecmdmenu, IFBURIED },
     { 'V', "history", "show long version and game history",
-            dohistory, IFBURIED | GENERALCMD },
+            nle_noop /* dohistory */, IFBURIED | GENERALCMD },
     { 'i', "inventory", "show your inventory", ddoinv, IFBURIED },
     { 'I', "inventtype", "inventory specific item types",
             dotypeinv, IFBURIED },
@@ -3421,7 +3441,7 @@ struct ext_func_tab extcmdlist[] = {
             dosacrifice, AUTOCOMPLETE },
     { 'o', "open", "open a door", doopen },
     { 'O', "options", "show option settings, possibly change them",
-            doset, IFBURIED | GENERALCMD },
+            nle_doset /* doset */, IFBURIED | GENERALCMD },
     { C('o'), "overview", "show a summary of the explored dungeon",
             dooverview, IFBURIED | AUTOCOMPLETE },
     { '\0', "panic", "test panic routine (fatal to game)",
@@ -3433,7 +3453,7 @@ struct ext_func_tab extcmdlist[] = {
     { M('p'), "pray", "pray to the gods for help",
             dopray, IFBURIED | AUTOCOMPLETE },
     { C('p'), "prevmsg", "view recent game messages",
-            doprev_message, IFBURIED | GENERALCMD },
+            nle_noop /* doprev_message */, IFBURIED | GENERALCMD },
     { 'P', "puton", "put on an accessory (ring, amulet, etc)", doputon },
     { 'q', "quaff", "quaff (drink) something", dodrink },
     { M('q'), "quit", "exit without saving current game",
@@ -3445,7 +3465,7 @@ struct ext_func_tab extcmdlist[] = {
     { M('R'), "ride", "mount or dismount a saddled steed",
             doride, AUTOCOMPLETE },
     { M('r'), "rub", "rub a lamp or a stone", dorub, AUTOCOMPLETE },
-    { 'S', "save", "save the game and exit", dosave, IFBURIED | GENERALCMD },
+    { 'S', "save", "save the game and exit", nle_dosave /* dosave */, IFBURIED | GENERALCMD },
     { 's', "search", "search for traps and secret doors",
             dosearch, IFBURIED, "searching" },
     { '*', "seeall", "show all equipment in use", doprinuse, IFBURIED },


### PR DESCRIPTION
This is the branch that contains the Challenge Environment and the NeurIPS baseline we will release for it. 

The key differences from `NetHackChallenge` to `NetHackScore` are:
* All menus allowed
* Full key board action space allowed (with underlying code for quit, save and options switched off)
* Rotating characters (`characeter = '@'`)
*  `PREV_MSG` and `HISTORY` actions are removed (they seemed to be causing crashes)

The model itself we submit as baseline is based heavily on the model in Neurips2020 paper, and posted on the branch here (`neurips2020release`).  Here we have taken the best model and cut out all the other elements of the model, to keep the baseline simple, and to try to keep the model to only one file. 

The results of this run (for rotating characters and single characters are visible [here](https://fairwandb.org/nethack/competition3/reports/Starter-Kit--VmlldzoxMzk5) ). 

My suspicion is the model has gotten a bit slower (6000 sps) so there is probably room for a speed up. We can do this after the competition has started.

