### PR TITLE
Change cmake install command.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 file(STRINGS "version.txt" NLE_VERSION)
 project(nle VERSION ${NLE_VERSION})
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ class CMakeBuild(build_ext.build_ext):
         ]
 
         build_cmd = ["cmake", "--build", ".", "--parallel"]
-        install_cmd = build_cmd + ["--target", "install"]
+        install_cmd = ["cmake", "--install", "."]
 
         try:
             subprocess.check_call(cmake_cmd, cwd=self.build_temp)


### PR DESCRIPTION
It seems a recent version of cmake (happened to me for cmake 3.20.0)
no longer installs nethackdir when called with
  cmake --build . --target install
Starting from cmake 3.15, the command
  cmake --install .
works instead (https://stackoverflow.com/a/56457739/1136208).

Fixes issues along the lines of
$ pip install -e .
$ python -m nle.scripts.play
FileNotFoundError: Couldn't find NetHack installation at '/Users/hnr/miniconda3/envs/extdev/lib/python3.8/site-packages/nle/nethackdir