### PR TITLE
Flag for not generating a random monster if not specified in the des-file

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -120,12 +120,16 @@ boolean resuming;
 
                     /* occasionally add another monster; since this takes
                        place after movement has been allotted, the new
-                       monster effectively loses its first turn */
-                    if (!rn2(u.uevent.udemigod ? 25
-                             : (depth(&u.uz) > depth(&stronghold_level)) ? 50
-                               : 70))
-                        (void) makemon((struct permonst *) 0, 0, 0,
-                                       NO_MM_FLAGS);
+                       monster effectively loses its first turn, unless
+                       random monster generation is turned off */
+                    if (!getenv("NH_NO_RAND_MON")) {
+                        if (!rn2(u.uevent.udemigod ? 25
+                                 : (depth(&u.uz) > depth(&stronghold_level))
+                                     ? 50
+                                     : 70))
+                            (void) makemon((struct permonst *) 0, 0, 0,
+                                           NO_MM_FLAGS);
+                    }
 
                     /* calculate how much time passed. */
                     if (u.usteed && u.umoved) {

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -4784,7 +4784,7 @@ struct sp_coder *coder;
     }
 
     walkfrom(x, y, OV_i(ftyp));
-    if (OV_i(fstocked))
+    if (OV_i(fstocked) && !getenv("NH_NO_RAND_MON"))
         fill_empty_maze();
 
     opvar_free(mcoord);


### PR DESCRIPTION
Added an environment variable $NH_NO_RAND_MON which if set disables [random monster generation after every game step](https://nethackwiki.com/wiki/Monster_creation#Random_generation). The flag also disables random monster/object placements in procedurally generated mazewalks.

The changes are within the NetHack source code.