### PR TITLE
Some fixes to NLE and the competition task

### DIFF
--- a/.github/workflows/lint_cc.yml
+++ b/.github/workflows/lint_cc.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Clone NLE repo
         uses: actions/checkout@v2
       - name: Run clang
-        run: "./nle/scripts/run-clang-format -r win/rl"
+        run: "./nle/scripts/run-clang-format -r win/rl src/nle.c sys/unix/nledl.c include/nle.h include/nledl.h include/nleobs.h"

--- a/.github/workflows/lint_cc.yml
+++ b/.github/workflows/lint_cc.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - master
     paths:
-      - "win/rl/**.{c,cc,cpp,h,hh,hpp}"
+      - "src/nle**.c"
+      - "include/nle**.h"
+      - "win/rl/**.cc"
   pull_request:
     paths:
-      - "win/rl/**.{c,cc,cpp,h,hh,hpp}"
+      - "src/nle**.c"
+      - "include/nle**.h"
+      - "win/rl/**.cc"
   schedule:
     - cron: "0 6,18 * * *"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,11 @@ repos:
     rev: 'v0.6.13'
     hooks:
     - id: cmake-format
+-   repo: local
+    hooks:
+    -   id: clang-format
+        name: clang-format
+        description: Format files with clang-format
+        entry: nle/scripts/run-clang-format
+        language: system
+        files: ^(src\/nle|include\/nle|win\/rl)\.(c|cc|cxx|cpp|cu|h|hpp|hxx|cuh|proto)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 21.6b0
     hooks:
     - id: black
       language_version: python3.8
-      exclude: scripts/plotting/*
+      exclude: scripts/plotting/.*
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: '3.7.9'
+    rev: '3.9.2'
     hooks:
     - id: flake8
-      exclude: scripts/plotting/*
+      exclude: scripts/plotting/.*
       additional_dependencies: [flake8-bugbear]
       args: ["--show-source"]
 -   repo: https://github.com/cheshirekow/cmake-format-precommit
-    rev: 'v0.6.10'
+    rev: 'v0.6.13'
     hooks:
     - id: cmake-format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,9 +88,10 @@ file(
 add_library(nethack SHARED ${NETHACK_SRC})
 add_dependencies(nethack util dat)
 set_target_properties(nethack PROPERTIES CXX_STANDARD 14 SUFFIX ".so")
-target_include_directories(nethack PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-                                          ${NLE_INC_GEN} /usr/local/include
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/third_party/libtmt)
+target_include_directories(
+  nethack
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${NLE_INC_GEN} /usr/local/include
+         ${CMAKE_CURRENT_SOURCE_DIR}/third_party/libtmt)
 target_link_directories(nethack PUBLIC /usr/local/lib)
 
 # Careful with -DMONITOR_HEAP: Ironically, it fails to fclose FILE* heaplog.

--- a/include/config.h
+++ b/include/config.h
@@ -55,6 +55,7 @@
 #define RL_GRAPHICS  /* Reinforcement learning 'window' port */
 
 #define NO_SIGNAL
+#define NOSHELL
 
 /*
  * Define the default window system.  This should be one that is compiled

--- a/include/nleobs.h
+++ b/include/nleobs.h
@@ -12,6 +12,8 @@
 #define NLE_TERM_CO 80
 #define NLE_TERM_LI 24
 
+/* #define NLE_ALLOW_SEEDING 1 */
+
 typedef struct nle_observation {
     int action;
     int done;
@@ -38,8 +40,10 @@ typedef struct nle_observation {
 } nle_obs;
 
 typedef struct {
+#ifdef NLE_ALLOW_SEEDING
     unsigned long seeds[2]; /* core, disp */
     char reseed; /* boolean: use NetHack's anti-TAS reseed mechanism? */
+#endif
 } nle_seeds_init_t;
 
 #endif /* NLEOBS_H */

--- a/nle/env/tasks.py
+++ b/nle/env/tasks.py
@@ -341,6 +341,13 @@ class NetHackChallenge(NetHackScore):
         # If the in-game turn count doesn't change for 10_000 steps, we abort
         self.no_progress_timeout = no_progress_timeout
 
+        def f(*args, **kwargs):
+            raise RuntimeError("Should not try changing seeds")
+
+        self.env.set_initial_seeds = f
+        self.env.set_current_seeds = f
+        self.env.get_current_seeds = f
+
     def reset(self, *args, **kwargs):
         self._turns = None
         self._no_progress_count = 0
@@ -360,3 +367,6 @@ class NetHackChallenge(NetHackScore):
             self._steps >= self._max_episode_steps
             or self._no_progress_count >= self.no_progress_timeout
         )
+
+    def seed(self, core=None, disp=None, reseed=True):
+        raise RuntimeError("NetHackChallenge doesn't allow seed changes")

--- a/nle/scripts/run-clang-format
+++ b/nle/scripts/run-clang-format
@@ -205,7 +205,7 @@ def print_diff(diff_lines, use_color):
     if use_color:
         diff_lines = colorize(diff_lines)
     if sys.version_info[0] < 3:
-        sys.stdout.writelines((l.encode("utf-8") for l in diff_lines))
+        sys.stdout.writelines((line.encode("utf-8") for line in diff_lines))
     else:
         sys.stdout.writelines(diff_lines)
 

--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -244,6 +244,11 @@ class TestGymEnvRollout:
 
     def test_seed_interface_output(self, env_name, rollout_len):
         """Tests whether env.seed output can be reused correctly."""
+        if not nethack.NLE_ALLOW_SEEDING:
+            return  # Nothing to test.
+        if env_name.startswith("NetHackChallenge"):
+            pytest.skip("Not running seed test on NetHackChallenge")
+
         env0 = gym.make(env_name)
         env1 = gym.make(env_name)
 
@@ -257,6 +262,11 @@ class TestGymEnvRollout:
 
     def test_seed_rollout_seeded(self, env_name, rollout_len):
         """Tests that two seeded envs return same step data."""
+        if not nethack.NLE_ALLOW_SEEDING:
+            return  # Nothing to test.
+        if env_name.startswith("NetHackChallenge"):
+            pytest.skip("Not running seed test on NetHackChallenge")
+
         env0 = gym.make(env_name)
         env1 = gym.make(env_name)
 
@@ -277,6 +287,11 @@ class TestGymEnvRollout:
 
     def test_seed_rollout_seeded_int(self, env_name, rollout_len):
         """Tests that two seeded envs return same step data."""
+        if not nethack.NLE_ALLOW_SEEDING:
+            return  # Nothing to test.
+        if env_name.startswith("NetHackChallenge"):
+            pytest.skip("Not running seed test on NetHackChallenge")
+
         env0 = gym.make(env_name)
         env1 = gym.make(env_name)
 
@@ -366,3 +381,21 @@ class TestGymDynamics:
 
         assert done
         assert reward == 0.0
+
+
+class TestNetHackChallenge:
+    def test_no_seed_setting(self):
+        assert not nethack.NLE_ALLOW_SEEDING
+
+        MESSAGE = "Should not try changing seeds"
+
+        env = gym.make("NetHackChallenge-v0")
+        with pytest.raises(
+            RuntimeError, match="NetHackChallenge doesn't allow seed changes"
+        ):
+            env.seed()
+        with pytest.raises(RuntimeError, match=MESSAGE):
+            env.env.set_initial_seeds(0, 0, True)
+
+        with pytest.raises(RuntimeError, match="Seeding not enabled"):
+            env.env._pynethack.set_initial_seeds(0, 0, True)

--- a/nle/tests/test_nethack.py
+++ b/nle/tests/test_nethack.py
@@ -120,7 +120,9 @@ class TestNetHack:
         finally:
             game1.close()
 
-    def test_set_initial_seedS(self):
+    def test_set_initial_seeds(self):
+        if not nethack.NLE_ALLOW_SEEDING:
+            return  # Nothing to test.
         game = nethack.Nethack(copy=True)
         game.set_initial_seeds(core=42, disp=666)
         obs0 = game.reset()
@@ -135,6 +137,9 @@ class TestNetHack:
             game.close()
 
     def test_set_seed_after_reset(self, game):
+        if not nethack.NLE_ALLOW_SEEDING:
+            return  # Nothing to test.
+
         game.reset()
         # Could fail on a system without a good source of randomness:
         assert game.get_current_seeds()[2] is True

--- a/nle/tests/test_profile.py
+++ b/nle/tests/test_profile.py
@@ -44,15 +44,18 @@ class TestProfile:
     @pytest.mark.benchmark(disable_gc=True, warmup=False)
     def test_run_1k_steps(self, observation_keys, make_cwd_tmp, benchmark):
         env = gym.make("NetHack-v0", observation_keys=observation_keys)
-        seeds = [123456]
+        seeds = 123456
         steps = 1000
 
-        np.random.seed(seeds[0])
+        np.random.seed(seeds)
         actions = np.random.choice(len(env._actions), size=steps)
 
         def seed():
-            seeds[0] += 1
-            env.seed(seeds[0], 2 * seeds[0])
+            if not nle.nethack.NLE_ALLOW_SEEDING:
+                return
+            nonlocal seeds
+            seeds += 1
+            env.seed(seeds, 2 * seeds)
 
         def play_1k_steps():
             env.reset()

--- a/src/nle.c
+++ b/src/nle.c
@@ -357,12 +357,14 @@ extern unsigned long NDECL(sys_random_seed);
 void
 init_random(int FDECL((*fn), (int) ))
 {
-    if (!nle_seeds_init) {
-        set_random(sys_random_seed(), fn);
+#ifdef NLE_ALLOW_SEEDING
+    if (nle_seeds_init) {
+        set_random(nle_seeds_init->seeds[whichrng(fn)], fn);
+        has_strong_rngseed = nle_seeds_init->reseed;
         return;
     }
-    set_random(nle_seeds_init->seeds[whichrng(fn)], fn);
-    has_strong_rngseed = nle_seeds_init->reseed;
+#endif
+    set_random(sys_random_seed(), fn);
 }
 
 nle_ctx_t *
@@ -430,6 +432,7 @@ nle_end(nle_ctx_t *nle)
     free(nle);
 }
 
+#ifdef NLE_ALLOW_SEEDING
 void
 nle_set_seed(nle_ctx_t *nle, unsigned long core, unsigned long disp,
              boolean reseed)
@@ -452,6 +455,7 @@ nle_get_seed(nle_ctx_t *nle, unsigned long *core, unsigned long *disp,
     *disp = nle_seeds[1];
     *reseed = has_strong_rngseed;
 }
+#endif
 
 /* From unixtty.c */
 /* fatal error */

--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -102,6 +102,7 @@ nle_end(nle_ctx_t *nledl)
     free(nledl);
 }
 
+#ifdef NLE_ALLOW_SEEDING
 void
 nle_set_seed(nle_ctx_t *nledl, unsigned long core, unsigned long disp,
              char reseed)
@@ -138,3 +139,4 @@ nle_get_seed(nle_ctx_t *nledl, unsigned long *core, unsigned long *disp,
      */
     get_seed(nledl->nle_ctx, core, disp, reseed);
 }
+#endif

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -178,23 +178,32 @@ class Nethack
     void
     set_initial_seeds(unsigned long core, unsigned long disp, bool reseed)
     {
+#ifdef NLE_ALLOW_SEEDING
         seed_init_.seeds[0] = core;
         seed_init_.seeds[1] = disp;
         seed_init_.reseed = reseed;
         use_seed_init = true;
+#else
+        throw std::runtime_error("Seeding not enabled");
+#endif
     }
 
     void
     set_seeds(unsigned long core, unsigned long disp, bool reseed)
     {
+#ifdef NLE_ALLOW_SEEDING
         if (!nle_)
             throw std::runtime_error("set_seed called without reset()");
         nle_set_seed(nle_, core, disp, reseed);
+#else
+        throw std::runtime_error("Seeding not enabled");
+#endif
     }
 
     std::tuple<unsigned long, unsigned long, bool>
     get_seeds()
     {
+#ifdef NLE_ALLOW_SEEDING
         if (!nle_)
             throw std::runtime_error("get_seed called without reset()");
         std::tuple<unsigned long, unsigned long, bool> result;
@@ -204,6 +213,9 @@ class Nethack
                      &reseed);
         std::get<2>(result) = reseed;
         return result;
+#else
+        throw std::runtime_error("Seeding not enabled");
+#endif
     }
 
     boolean
@@ -289,6 +301,13 @@ PYBIND11_MODULE(_pynethack, m)
     mn.attr("NLE_INVENTORY_STR_LENGTH") = py::int_(NLE_INVENTORY_STR_LENGTH);
     mn.attr("NLE_SCREEN_DESCRIPTION_LENGTH") =
         py::int_(NLE_SCREEN_DESCRIPTION_LENGTH);
+
+    mn.attr("NLE_ALLOW_SEEDING") =
+#ifdef NLE_ALLOW_SEEDING
+        true;
+#else
+        false;
+#endif
 
     /* NetHack constants. */
     mn.attr("ROWNO") = py::int_(ROWNO);

--- a/win/rl/winrl.cc
+++ b/win/rl/winrl.cc
@@ -178,7 +178,8 @@ class NetHackRL
     std::array<uint8_t, (COLNO - 1) * ROWNO> colors_;
     std::array<uint8_t, (COLNO - 1) * ROWNO> specials_;
 
-    std::array<char, (COLNO - 1) * ROWNO * NLE_SCREEN_DESCRIPTION_LENGTH> screen_descriptions_;
+    std::array<char, (COLNO - 1) * ROWNO * NLE_SCREEN_DESCRIPTION_LENGTH>
+        screen_descriptions_;
 
     void store_glyph(XCHAR_P x, XCHAR_P y, int glyph);
     void store_mapped_glyph(int ch, int color, int special, XCHAR_P x,
@@ -507,9 +508,11 @@ NetHackRL::store_screen_description(XCHAR_P x, XCHAR_P y, int glyph)
 
     if (do_screen_description(cc, TRUE, sym, tmpbuf, &firstmatch,
                               (struct permonst **) 0)) {
-        strncpy((char *) &screen_descriptions_ + start, firstmatch, NLE_SCREEN_DESCRIPTION_LENGTH);
+        strncpy((char *) &screen_descriptions_ + start, firstmatch,
+                NLE_SCREEN_DESCRIPTION_LENGTH);
     } else {
-        strncpy((char *) &screen_descriptions_ + start, "", NLE_SCREEN_DESCRIPTION_LENGTH);
+        strncpy((char *) &screen_descriptions_ + start, "",
+                NLE_SCREEN_DESCRIPTION_LENGTH);
     }
 }
 
@@ -640,7 +643,7 @@ NetHackRL::add_menu_method(
     int attr,                   /* attribute for string (like putstr()) */
     const char *str,            /* menu string */
     bool preselected            /* item is marked as selected */
-    )
+)
 {
     DEBUG_API("rl_add_menu" << std::endl);
     tty_add_menu(wid, glyph, identifier, ch, gch, attr, str, preselected);


### PR DESCRIPTION
This PR fixes our C++ lint test (which apparently never really worked and at any rate was broken for months now) and flat-out disables seeding in NLE. The seeding commit is rather defensive for purposes of the NLE competition. Afterwards, we can `#define NLE_ALLOW_SEEDING 1` to turn on the old behaviour.