### PR TITLE
Default savedir to None (and remove unused archivefile)

### DIFF
--- a/nle/agent/agent.py
+++ b/nle/agent/agent.py
@@ -430,7 +430,7 @@ def train(flags):  # pylint: disable=too-many-branches, too-many-statements
         logging.info("Not using CUDA.")
         flags.device = torch.device("cpu")
 
-    env = create_env(flags.env, archivefile=None)
+    env = create_env(flags.env)
     observation_space = env.observation_space
     action_space = env.action_space
     del env  # End this before forking.
@@ -592,7 +592,7 @@ def test(flags, num_episodes=10):
     flags.savedir = os.path.expandvars(os.path.expanduser(flags.savedir))
     checkpointpath = os.path.join(flags.savedir, "latest", "model.tar")
 
-    gym_env = create_env(flags.env, archivefile=None)
+    gym_env = create_env(flags.env)
     env = ResettingEnvironment(gym_env)
     model = Net(gym_env.observation_space, gym_env.action_space.n, flags.use_lstm)
     model.eval()

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -186,8 +186,7 @@ class NLE(gym.Env):
 
     def __init__(
         self,
-        savedir="",
-        archivefile="nethack.%(pid)i.%(time)s.zip",
+        savedir=None,
         character="mon-hum-neu-mal",
         max_episode_steps=5000,
         observation_keys=(

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -187,6 +187,7 @@ class NLE(gym.Env):
     def __init__(
         self,
         savedir=None,
+        archivefile=None,
         character="mon-hum-neu-mal",
         max_episode_steps=5000,
         observation_keys=(


### PR DESCRIPTION
savedir is a feature that will save ttyrecs of runs - this can be unexpected when training a model and may write a *huge* amount of unwanted files.

This changes the default to *not* save ttyrecs.

If you want ttyrecs to be saved, please specify savedir when instantiating the env from now on.

`archivefile` is a parameter that may have been used at some point, but is currently unused, so let's remove it.