### PR TITLE
Quick typo correction

### DIFF
--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -293,7 +293,7 @@ class NLE(gym.Env):
         if "internal" in self._observation_keys:
             logger.warn(
                 """The 'internal' NLE observation was requested.
-This might contain data that shouldn't be abailable to agents."""
+This might contain data that shouldn't be available to agents."""
             )
 
         # Observations we always need.


### PR DESCRIPTION
Noticed a typo in `base.py`