### PR TITLE
Be less silly, no more `std::unique_ptr<std::FILE, int (*)(std::FILE *)>`

### DIFF
--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -226,9 +226,9 @@ class NLE(gym.Env):
 
         Args:
             savedir (str or None): path to save ttyrecs (game recordings) into.
-                Defaults to "" (empty string), which makes NLE chose the
-                directory name. If None, don't save any data. Otherwise,
+                Defaults to None, which doesn't save any data. Otherwise,
                 interpreted as a path to a new or existing directory.
+                If "" (empty string), NLE choses a unique directory name.
             character (str): name of character. Defaults to "mon-hum-neu-mal".
             max_episode_steps (int): maximum amount of steps allowed before the
                 game is forcefully quit. In such cases, ``info["end_status"]``

--- a/nle/scripts/play.py
+++ b/nle/scripts/play.py
@@ -258,6 +258,8 @@ def main():
             FLAGS.savedir = "{}_{}_{}.zip".format(
                 time.strftime("%Y%m%d-%H%M%S"), FLAGS.mode, FLAGS.env
             )
+        elif FLAGS.savedir == "None":
+            FLAGS.savedir = None  # Not saving any ttyrecs.
 
         play()
 


### PR DESCRIPTION
![image](https://media1.tenor.com/images/d176485a594310ce14bbae1f202f2363/tenor.gif?itemid=19640759)

Also fix `savedir` docstring, make play.py able to do `savedir=None`.

Also also update pybind11 version to 2.6.2.