### PR TITLE
Fix minor string issue

### DIFF
--- a/nle/scripts/read_tty.py
+++ b/nle/scripts/read_tty.py
@@ -67,13 +67,13 @@ if __name__ == "__main__":
                 data = action
                 channel = "->"
 
-            data = re.sub(r"\\x1b\[([0-9];?)*.", lambda m: color(m.group(0), 8), data)
+            data = re.sub(r"\\x1b\[([0-9];?)*.", lambda m: color(m.group(0), 8), str(data))
             data = re.sub(
                 r"(\\x1b\(0)(.*?)(\\x1b\(B)",
                 lambda m: (
                     color(m.group(1), 4) + color(m.group(2), 3) + color(m.group(3), 4)
                 ),
-                data,
+                str(data),
             )
 
             print(


### PR DESCRIPTION
I think for some python versions, ints arent automatically converted to strings

```python
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/ubuntu/anaconda3/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/nle/scripts/read_tty.py", line 70, in <module>
    data = re.sub(r"\\x1b\[([0-9];?)*.", lambda m: color(m.group(0), 8), data)
  File "/home/ubuntu/anaconda3/lib/python3.7/re.py", line 192, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
```