### PR TITLE
Don't chdir in NLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,8 @@ add_compile_definitions(
   NOTPARMDECL
   HACKDIR="${HACKDIR}"
   DEFAULT_WINDOW_SYS="rl"
-  DLB)
+  DLB
+  NOCWD_ASSUMPTIONS)
 
 set(NLE_SRC ${nle_SOURCE_DIR}/src)
 set(NLE_INC ${nle_SOURCE_DIR}/include)

--- a/dat/CMakeLists.txt
+++ b/dat/CMakeLists.txt
@@ -250,16 +250,15 @@ add_custom_command(
   COMMAND $<TARGET_FILE:lev_comp> ${QUEST_LEVELS})
 
 add_custom_command(
-  OUTPUT perm record logfile xlogfile sysconf
-  COMMAND ${CMAKE_COMMAND} -E touch perm record logfile xlogfile
-  COMMAND ${CMAKE_COMMAND} -E echo "WIZARDS=*" > sysconf)
+  OUTPUT perm record logfile xlogfile COMMAND ${CMAKE_COMMAND} -E touch perm
+                                              record logfile xlogfile)
 
 add_custom_command(
   DEPENDS dlb ${DATDLB} ${LEVS_GEN}
   OUTPUT nhdat
   COMMAND LC_ALL=C $<TARGET_FILE:dlb> ARGS cf nhdat ${DATDLB} ${LEVS_GEN})
 
-set(ALL_DAT_GEN nhdat perm record logfile xlogfile sysconf)
+set(ALL_DAT_GEN nhdat perm record logfile xlogfile)
 list(TRANSFORM ALL_DAT_GEN PREPEND ${NLE_DAT_GEN}/)
 
 add_custom_target(dat ALL DEPENDS ${ALL_DAT_GEN} ${ALL_DAT_NOTGEN})

--- a/include/config.h
+++ b/include/config.h
@@ -205,12 +205,13 @@
  */
 
 #ifndef WIZARD_NAME /* allow for compile-time or Makefile changes */
-#define WIZARD_NAME "wizard" /* value is ignored if SYSCF is enabled */
+#define WIZARD_NAME "*" /* value is ignored if SYSCF is enabled */
 #endif
 
 #ifndef SYSCF
-#define SYSCF                /* use a global configuration */
-#define SYSCF_FILE "sysconf" /* global configuration is in a file */
+/* NLE: Don't enable SYSCF. */
+/*#define SYSCF*/                /* use a global configuration */
+/*#define SYSCF_FILE "sysconf"*/ /* global configuration is in a file */
 #endif
 
 #ifndef GDBPATH

--- a/include/config.h
+++ b/include/config.h
@@ -356,7 +356,7 @@
 /* #define INSURANCE allow crashed game recovery */
 
 #ifndef MAC
-#define CHDIR /* delete if no chdir() available */
+/* #define CHDIR */ /* delete if no chdir() available */ /* Deleted for NLE */
 #endif
 
 #ifdef CHDIR

--- a/include/extern.h
+++ b/include/extern.h
@@ -781,6 +781,8 @@ E void NDECL(makerogueghost);
 
 /* ### files.c ### */
 
+E void FDECL(append_slash, (char *));  /* Moved for NLE. */
+
 E char *FDECL(fname_encode, (const char *, CHAR_P, char *, char *, int));
 E char *FDECL(fname_decode, (CHAR_P, char *, char *, int));
 E const char *FDECL(fqname, (const char *, int, int));

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -98,7 +98,7 @@ class Nethack:
         self._copy = copy
 
         if not os.path.exists(hackdir) or not os.path.exists(
-            os.path.join(hackdir, "sysconf")
+            os.path.join(hackdir, "nhdat")
         ):
             raise FileNotFoundError(
                 "Couldn't find NetHack installation at '%s'." % hackdir
@@ -112,9 +112,8 @@ class Nethack:
         # directory on loading.
         self._oldcwd = os.getcwd()
 
-        # Symlink a few files.
-        for fn in ["nhdat", "sysconf"]:
-            os.symlink(os.path.join(hackdir, fn), os.path.join(self._vardir, fn))
+        # Symlink a nhdat.
+        os.symlink(os.path.join(hackdir, "nhdat"), os.path.join(self._vardir, "nhdat"))
         # Touch a few files.
         for fn in ["perm", "logfile", "xlogfile"]:
             os.close(os.open(os.path.join(self._vardir, fn), os.O_CREAT))

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -74,7 +74,7 @@ def _set_env_vars(options, hackdir, wizkit=None):
     os.environ["HACKDIR"] = hackdir
     os.environ["TERM"] = "ansi"
     if wizkit is not None:
-        os.environ["WIZKIT"] = wizkit
+        os.environ["WIZKIT"] = os.path.join(hackdir, wizkit)
 
 
 # TODO: Not thread-safe for many reasons.

--- a/nle/tests/test_nethack.py
+++ b/nle/tests/test_nethack.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import timeit
+import os
 import random
+import timeit
 import warnings
 
 import numpy as np
@@ -51,7 +52,7 @@ class TestNetHack:
         game.close()
 
     def test_run_n_episodes(self, tmpdir, game, episodes=3):
-        olddir = tmpdir.chdir()
+        olddir = tmpdir.chdir()  # tmpdir is a py.path.local object.
 
         chars, blstats = game.reset()
 
@@ -93,10 +94,8 @@ class TestNetHack:
 
         print("Finished after %i steps. Mean sps: %f" % (steps, mean_sps))
 
-        nethackdir = tmpdir.chdir()
-
-        assert nethackdir.fnmatch("nle*")
-        assert tmpdir.ensure("nle.ttyrec")
+        # Resetting the game shouldn't have caused cwd to change.
+        assert tmpdir.samefile(os.getcwd())
 
         if mean_sps < 15000:
             warnings.warn("Mean sps was only %f" % mean_sps)
@@ -149,9 +148,6 @@ class TestNetHack:
 
 class TestNetHackFurther:
     def test_run(self):
-        # TODO: Implement ttyrecording filename in libnethack wrapper.
-        # archivefile = tempfile.mktemp(suffix="nethack_test", prefix=".zip")
-
         game = nethack.Nethack(
             observation_keys=("glyphs", "chars", "colors", "blstats", "program_state")
         )
@@ -196,6 +192,7 @@ class TestNetHackFurther:
             assert class_sym.explain == "human or elf"
 
         game.close()
+        assert os.path.isfile(os.path.join(os.getcwd(), "nle.ttyrec.bz2"))
 
     def test_illegal_filename(self):
         with pytest.raises(IOError):

--- a/nle/tests/test_profile.py
+++ b/nle/tests/test_profile.py
@@ -5,6 +5,7 @@
 # Requires
 #   pip install pytest-benchmark
 # to run
+import os
 
 import pytest
 
@@ -35,14 +36,17 @@ EXPERIMENTS = {
     "observation_keys", EXPERIMENTS.values(), ids=EXPERIMENTS.keys()
 )
 class TestProfile:
-    @pytest.yield_fixture(autouse=True)  # will be applied to all tests in class
+    @pytest.fixture(autouse=True)
     def make_cwd_tmp(self, tmpdir):
         """Makes cwd point to the test's tmpdir."""
         with tmpdir.as_cwd():
             yield
 
     @pytest.mark.benchmark(disable_gc=True, warmup=False)
-    def test_run_1k_steps(self, observation_keys, make_cwd_tmp, benchmark):
+    def test_run_1k_steps(self, observation_keys, benchmark):
+        if os.environ.get("CI") == "true":
+            pytest.skip("Not running benchmark on CI")
+
         env = gym.make("NetHack-v0", observation_keys=observation_keys)
         seeds = 123456
         steps = 1000

--- a/src/nle.c
+++ b/src/nle.c
@@ -162,6 +162,8 @@ init_nle(FILE *ttyrec, nle_obs *obs)
     return nle;
 }
 
+static char nle_path[4096];
+
 /* TODO: Consider copying the relevant parts of main() in unixmain.c. */
 void
 mainloop(fcontext_transfer_t ctx_transfer)
@@ -178,6 +180,39 @@ mainloop(fcontext_transfer_t ctx_transfer)
     ASAN_UNPOISON_MEMORY_REGION((char *) stack->sptr - stack->ssize,
                                 stack->ssize);
 #endif
+
+    const char *p;
+
+    p = nh_getenv("HACKDIR");
+    if (!p || !*p) {
+        error("HACKDIR not set");
+        return;
+    }
+
+    int len = strlen(p);
+    if (len >= sizeof nle_path - 1) {
+        error("HACKDIR too long");
+        return;
+    }
+
+    strncpy(nle_path, p, sizeof nle_path - 1);
+    if (nle_path[len - 1] != '/') {
+        nle_path[len] = '/';
+        nle_path[len + 1] = '\0';
+    } else {
+        nle_path[len] = '\0';
+    }
+
+    fqn_prefix[SYSCONFPREFIX] = nle_path;
+    fqn_prefix[CONFIGPREFIX] = nle_path;
+    fqn_prefix[HACKPREFIX] = nle_path;
+    fqn_prefix[SAVEPREFIX] = nle_path;
+    fqn_prefix[LEVELPREFIX] = nle_path;
+    fqn_prefix[BONESPREFIX] = nle_path;
+    fqn_prefix[SCOREPREFIX] = nle_path;
+    fqn_prefix[LOCKPREFIX] = nle_path;
+    fqn_prefix[TROUBLEPREFIX] = nle_path;
+    fqn_prefix[DATAPREFIX] = nle_path;
 
     char *argv[1] = { "nethack" };
 


### PR DESCRIPTION
Also don't use `sysconf`, which is saner than carrying it around and goes along well with this change.

Misc. fixes to tests.

Fixes #132 and (hopefully!) #193.