### PR TITLE
Change `stable` to `latest` tag for our docker images.

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -55,6 +55,6 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: ${{ format('fairnle/nle-{0}', matrix.distro) }}
         dockerfile: ${{ format('docker/Dockerfile-{0}', matrix.distro) }}
-        tags: ${{ github.event.release.tag_name }},stable
+        tags: ${{ github.event.release.tag_name }},latest
         add_git_labels: true
         push: true


### PR DESCRIPTION
Adding this tag means we can do `docker pull fairnle/nle-xenial` and the
`latest` tag will be selected, instead of having to specify `docker pull
fairnle/nle-xenial:v0.7.2` etc.