### PR TITLE
Disabling seeding in NLE using an environment varariable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,15 @@ add_compile_definitions(
   DLB
   NOCWD_ASSUMPTIONS)
 
+option(USE_SEEDING "Use seeding support in NLE" ON)
+
+if(USE_SEEDING)
+  add_compile_definitions(NLE_ALLOW_SEEDING)
+  message("Seeding enabled.")
+else()
+  message("Seeding disabled.")
+endif()
+
 set(NLE_SRC ${nle_SOURCE_DIR}/src)
 set(NLE_INC ${nle_SOURCE_DIR}/include)
 set(NLE_DAT ${nle_SOURCE_DIR}/dat)

--- a/include/nleobs.h
+++ b/include/nleobs.h
@@ -41,7 +41,7 @@
 #define NLE_BL_DLEVEL 24
 #define NLE_BL_CONDITION 25 /* condition bit mask */
 
-/* #define NLE_ALLOW_SEEDING 1 */
+/* #define NLE_ALLOW_SEEDING 1 */ /* Set in CMakeLists.txt if not disabled. */
 
 typedef struct nle_observation {
     int action;

--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -385,17 +385,14 @@ class TestGymDynamics:
 
 class TestNetHackChallenge:
     def test_no_seed_setting(self):
-        assert not nethack.NLE_ALLOW_SEEDING
-
-        MESSAGE = "Should not try changing seeds"
-
         env = gym.make("NetHackChallenge-v0")
         with pytest.raises(
             RuntimeError, match="NetHackChallenge doesn't allow seed changes"
         ):
             env.seed()
-        with pytest.raises(RuntimeError, match=MESSAGE):
+        with pytest.raises(RuntimeError, match="Should not try changing seeds"):
             env.env.set_initial_seeds(0, 0, True)
 
-        with pytest.raises(RuntimeError, match="Seeding not enabled"):
-            env.env._pynethack.set_initial_seeds(0, 0, True)
+        if not nethack.NLE_ALLOW_SEEDING:
+            with pytest.raises(RuntimeError, match="Seeding not enabled"):
+                env.env._pynethack.set_initial_seeds(0, 0, True)

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,9 @@ class CMakeBuild(build_ext.build_ext):
 
         generator = "Ninja" if spawn.find_executable("ninja") else "Unix Makefiles"
 
+        use_seeding = os.environ.get("USE_SEEDING", "ON")
+        use_seeding = {"1": "ON", "0": "OFF"}.get(use_seeding, use_seeding.upper())
+
         cmake_cmd = [
             "cmake",
             str(source_path),
@@ -59,13 +62,8 @@ class CMakeBuild(build_ext.build_ext):
             "-DHACKDIR=%s" % hackdir_path,
             "-DPYTHON_INCLUDE_DIR=%s" % sysconfig.get_python_inc(),
             "-DPYTHON_LIBRARY=%s" % sysconfig.get_config_var("LIBDIR"),
+            "-DUSE_SEEDING=%s" % use_seeding,
         ]
-
-        use_seeding = os.environ.get("USE_SEEDING", True)
-        if use_seeding == "OFF":
-            use_seeding = False
-        if not int(use_seeding):
-            cmake_cmd.append("-DUSE_SEEDING=OFF")
 
         build_cmd = ["cmake", "--build", ".", "--parallel"]
         install_cmd = ["cmake", "--install", "."]

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@
 #  HACKDIR
 #    If set, install NetHack's data files in this directory.
 #
+#  USE_SEEDING
+#    If set, seeding is disabled in all NLE environments.
+#
 import os
 import pathlib
 import subprocess
@@ -57,6 +60,12 @@ class CMakeBuild(build_ext.build_ext):
             "-DPYTHON_INCLUDE_DIR=%s" % sysconfig.get_python_inc(),
             "-DPYTHON_LIBRARY=%s" % sysconfig.get_config_var("LIBDIR"),
         ]
+
+        use_seeding = os.environ.get("USE_SEEDING", True)
+        if use_seeding == "OFF":
+            use_seeding = False
+        if not int(use_seeding):
+            cmake_cmd.append("-DUSE_SEEDING=OFF")
 
         build_cmd = ["cmake", "--build", ".", "--parallel"]
         install_cmd = ["cmake", "--install", "."]


### PR DESCRIPTION
Uses an environment variable called `NLE_DISABLE_SEEDING` to disable seeding in NLE. If it is not set (which is usually expected), seeding is enabled.

Here are the commands I used to test the functionality
```bash
$ pip install -e .
$ python -c 'import gym; import nle; env = gym.make("NetHackScore-v0"); env.reset(); print(env.seed(1))'
(1, 5336406323662859033, False)

$ export NLE_DISABLE_SEEDING=1
$ pip install -e .
$ python -c 'import gym; import nle; env = gym.make("NetHackScore-v0"); env.reset(); print(env.seed(1))'
Traceback (most recent call last):
File "<string>", line 1, in <module>
File "/Users/samvelyan/workspace/NLE_fb/nle/nle/env/base.py", line 533, in seed
self.env.set_initial_seeds(core, disp, reseed)
File "/Users/samvelyan/workspace/NLE_fb/nle/nle/nethack/nethack.py", line 191, in set_initial_seeds
self._pynethack.set_initial_seeds(core, disp, reseed)
RuntimeError: Seeding not enabled

$ ./nle/scripts/nh-clean-install
$ export NLE_DISABLE_SEEDING=0
$ pip install -e .
$ python -c 'import gym; import nle; env = gym.make("NetHackScore-v0"); env.reset(); print(env.seed(1))'
(1, 8242861833433268597, False)
```