### PR TITLE
Create empty "record" file in NLE's HACKDIR.

### DIFF
--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -115,7 +115,7 @@ class Nethack:
         # Symlink a nhdat.
         os.symlink(os.path.join(hackdir, "nhdat"), os.path.join(self._vardir, "nhdat"))
         # Touch a few files.
-        for fn in ["perm", "logfile", "xlogfile"]:
+        for fn in ["perm", "record", "logfile", "xlogfile"]:
             os.close(os.open(os.path.join(self._vardir, fn), os.O_CREAT))
         os.mkdir(os.path.join(self._vardir, "save"))
 


### PR DESCRIPTION
I wonder how this even worked before? At any rate this seems obviously
necessary.

Fixes  https://github.com/facebookresearch/nle/issues/222.