### PR TITLE
Removing extra whitespace from BL_MASK_STRNGL and BL_MASK_TERMILL

### DIFF
--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -427,10 +427,10 @@ PYBIND11_MODULE(_pynethack, m)
     // From botl.h.
     mn.attr("BL_MASK_STONE") = py::int_(static_cast<int>(BL_MASK_STONE));
     mn.attr("BL_MASK_SLIME") = py::int_(static_cast<int>(BL_MASK_SLIME));
-    mn.attr("BL_MASK_STRNGL  ") = py::int_(static_cast<int>(BL_MASK_STRNGL));
+    mn.attr("BL_MASK_STRNGL") = py::int_(static_cast<int>(BL_MASK_STRNGL));
     mn.attr("BL_MASK_FOODPOIS") =
         py::int_(static_cast<int>(BL_MASK_FOODPOIS));
-    mn.attr("BL_MASK_TERMILL ") = py::int_(static_cast<int>(BL_MASK_TERMILL));
+    mn.attr("BL_MASK_TERMILL") = py::int_(static_cast<int>(BL_MASK_TERMILL));
     mn.attr("BL_MASK_BLIND") = py::int_(static_cast<int>(BL_MASK_BLIND));
     mn.attr("BL_MASK_DEAF") = py::int_(static_cast<int>(BL_MASK_DEAF));
     mn.attr("BL_MASK_STUN") = py::int_(static_cast<int>(BL_MASK_STUN));


### PR DESCRIPTION
Removing extra whitespace from BL_MASK_STRNGL and BL_MASK_TERMILL so that they export correctly to Python.  Credit to EulersApprentice for catching this problem.

Original problem report:
```
EulersApprentice — Today at 5:30 PM

All of the constants seem to work... except BL_MASK_STRNGL and BL_MASK_TERMILL, which both give the following error:
AttributeError: module 'nle.nethack' has no attribute 'BL_MASK_STRNGL'/'BL_MASK_TERMILL'
Looking at the constants in botl.h, I don't think I'm misspelling them? Or maybe the constants are defined in a different place from where I'm looking, and are spelled differently in that other place?
Stranger still is the fact that my IDE lets me tab-autocomplete nethack.BL_MASK_STRNGL and BL_MASK_TERMILL, but then it still gives me the same error.
```