### PR TITLE
Expose Monster Difficulty attribute of permonst struct through FFI

### DIFF
--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -539,6 +539,8 @@ PYBIND11_MODULE(_pynethack, m)
                       &permonst::mflags2) /* more boolean bitflags */
         .def_readonly("mflags3",
                       &permonst::mflags3) /* yet more boolean bitflags */
+        .def_readonly("difficulty",
+                      &permonst::difficulty) /* monster difficulty */
 #ifdef TEXTCOLOR
         .def_readonly("mcolor", &permonst::mcolor) /* color to use */
 #endif


### PR DESCRIPTION
Exposing the difficulty attribute of the `permonst` struct

Resolves #235 