### PR TITLE
Run finalizer correctly even when _pynethack.Nethack creation fails.

### DIFF
--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -195,6 +195,9 @@ class Nethack:
         #    process exit.)
         self._dl, dlpath = _new_dl(self._vardir)
 
+        # Finalize even when the rest of this constructor fails.
+        self._finalizer = weakref.finalize(self, _close, None, self._dl, self._tempdir)
+
         if options is None:
             options = NETHACKOPTIONS
         self._options = list(options) + ["name:" + playername]
@@ -209,6 +212,7 @@ class Nethack:
             self._pynethack = _pynethack.Nethack(dlpath, ttyrec, spawn_monsters)
         self._ttyrec = ttyrec
 
+        self._finalizer.detach()
         self._finalizer = weakref.finalize(
             self, _close, self._pynethack, self._dl, self._tempdir
         )


### PR DESCRIPTION
This is triggered in the test_illegal_filename test in test_nethack.py.