### PR TITLE
Alternative fix for gym 0.21 changes.

### DIFF
--- a/nle/env/__init__.py
+++ b/nle/env/__init__.py
@@ -1,23 +1,34 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import gym
 from gym.envs import registration
 
 from nle.env.base import NLE, DUNGEON_SHAPE
 
-registration.register(id="NetHack-v0", entry_point="nle.env.base:NLE")
+_version = "v0"
 
-registration.register(id="NetHackScore-v0", entry_point="nle.env.tasks:NetHackScore")
-registration.register(
-    id="NetHackStaircase-v0", entry_point="nle.env.tasks:NetHackStaircase"
-)
-registration.register(
-    id="NetHackStaircasePet-v0", entry_point="nle.env.tasks:NetHackStaircasePet"
-)
-registration.register(id="NetHackOracle-v0", entry_point="nle.env.tasks:NetHackOracle")
-registration.register(id="NetHackGold-v0", entry_point="nle.env.tasks:NetHackGold")
-registration.register(id="NetHackEat-v0", entry_point="nle.env.tasks:NetHackEat")
-registration.register(id="NetHackScout-v0", entry_point="nle.env.tasks:NetHackScout")
-registration.register(
-    id="NetHackChallenge-v0", entry_point="nle.env.tasks:NetHackChallenge"
-)
+for name in (
+    "NetHack",
+    "NetHackScore",
+    "NetHackStaircase",
+    "NetHackStaircasePet",
+    "NetHackOracle",
+    "NetHackGold",
+    "NetHackEat",
+    "NetHackScout",
+    "NetHackChallenge",
+):
+    entry_point = "nle.env.tasks:" + name
+    if name == "NetHack":
+        entry_point = "nle.env.base:NLE"
+    kwargs = {}
+    if gym.__version__ >= "0.21":
+        # Starting with version 0.21, gym wraps everything by the
+        # OrderEnforcing wrapper by default (which isn't in gym.wrappers).
+        # This breaks our seed() calls and some other code. Disable.
+        kwargs["order_enforce"] = False
+    registration.register(
+        id="%s-%s" % (name, _version), entry_point=entry_point, **kwargs
+    )
+
 
 __all__ = ["NLE", "DUNGEON_SHAPE"]


### PR DESCRIPTION
This is an alternative to https://github.com/facebookresearch/nle/pull/269 to fix #272.

----

The most recent version of gym wraps environments with the `OrderEnforcing` wrapper (https://github.com/openai/gym/blob/master/docs/wrappers.md) if not disabled. This breaks our [tests](https://github.com/facebookresearch/nle/pull/268/checks?check_run_id=3821174783), `play.py` and a number of other places. For instance, `env.seed()` with more than 1 argument now also fails due to [`gym.Wrapper.seed`](https://github.com/openai/gym/blob/master/gym/core.py#L300). Possible fixes:
* Use `env.unwrapped` when arguments to `seed` are given
* Disable the `OrderEnforcing` wrapper. This will break NLE when using earlier versions of the gym library unless we do per-version magic (as in this PR). We cannot test for the presence of `OrderEnforcing` as it's not exported into `gym.wrappers` (_sigh_).
* Adhere to the gym environment better by doing `seed(self, (core, disp, reseed))` instead of `seed(self, core=None, disp=None, reseed=False)`.

We also use `env._actions` a bunch of times, in tests and in `play.py`. We should fix that, and other accesses to `_underscored` variables.