### PR TITLE
Suggest --gpus all flag when running our Dockerfiles.

### DIFF
--- a/docker/Dockerfile-bionic
+++ b/docker/Dockerfile-bionic
@@ -54,7 +54,7 @@ CMD ["/bin/bash"]
 
 # Docker commands:
 #   docker rm nle -v
-#   docker build -t nle -f docker/Dockerfile .
-#   docker run --rm --name nle nle
+#   docker build -t nle -f docker/Dockerfile-bionic .
+#   docker run --gpus all --rm --name nle nle
 # or
-#   docker run -it --entrypoint /bin/bash nle
+#   docker run --gpus all -it --entrypoint /bin/bash nle

--- a/docker/Dockerfile-focal
+++ b/docker/Dockerfile-focal
@@ -40,7 +40,7 @@ CMD ["/bin/bash"]
 
 # Docker commands:
 #   docker rm nle -v
-#   docker build -t nle -f docker/Dockerfile .
-#   docker run --rm --name nle nle
+#   docker build -t nle -f docker/Dockerfile-focal .
+#   docker run --gpus all --rm --name nle nle
 # or
-#   docker run -it --entrypoint /bin/bash nle
+#   docker run --gpus all -it --entrypoint /bin/bash nle

--- a/docker/Dockerfile-xenial
+++ b/docker/Dockerfile-xenial
@@ -56,6 +56,6 @@ CMD ["/bin/bash"]
 # Docker commands:
 #   docker rm nle -v
 #   docker build -t nle -f docker/Dockerfile-xenial .
-#   docker run --rm --name nle nle
+#   docker run --gpus all --rm --name nle nle
 # or
-#   docker run -it --entrypoint /bin/bash nle
+#   docker run --gpus all -it --entrypoint /bin/bash nle

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,7 @@ You can try out the latest stable version in Ubuntu 18.04 by doing:
 
 ```bash
 $ docker pull fairnle/nle:stable
-$ docker run --rm -it fairnle/nle:stable python  # or bash
+$ docker run --gpus all --rm -it fairnle/nle:stable python  # or bash
 # Then you can simply use the nle package as normal
 ```
 
@@ -35,10 +35,13 @@ version of `nle`, following a specific templates:
 
 # Building images locally
 
-To build any of them (e.g. `Dockerfile-bionic`) do:
+To build and run any of them (e.g. `Dockerfile-bionic`) do:
 
 ```bash
 $ git clone https://github.com/facebookresearch/nle --recursive
 $ cd nle
-$ docker build -f docker/Dockerfile-bionic . -t nle:latest
+$ docker build -f docker/Dockerfile-bionic . -t nle
+$ docker run --gpus all --rm --name nle nle
+# or alternatively
+$ docker run --gpus all -it --entrypoint /bin/bash nle
 ```


### PR DESCRIPTION
Given that we use the nvidia/cuda:... images, this seems to make
sense.