### PR TITLE
Fix #297

### DIFF
--- a/include/tradstdc.h
+++ b/include/tradstdc.h
@@ -429,10 +429,12 @@ typedef genericptr genericptr_t; /* (void *) or (char *) */
 #if __GNUC__ >= 3
 #define UNUSED __attribute__((unused))
 #define NORETURN __attribute__((noreturn))
+#if !defined(__linux__) || defined(GCC_URWARN)
 /* disable gcc's __attribute__((__warn_unused_result__)) since explicitly
    discarding the result by casting to (void) is not accepted as a 'use' */
 #define __warn_unused_result__ /*empty*/
 #define warn_unused_result /*empty*/
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
NetHack redefined `__warn_unused_result__` in tradstdc.h which is really a bit naughty. Fixed upstream in NH 3.7 in https://github.com/NetHack/NetHack/commit/1cb5dc04605daa45f1c6a647c17442ed7ff2fe4e, cherry-picked here.

Fixes #297.