### PR TITLE
Fix _underscore access, rename Nethack variable as `nethack`.

### DIFF
--- a/nle/env/tasks.py
+++ b/nle/env/tasks.py
@@ -198,7 +198,7 @@ class NetHackGold(NetHackScore):
         """Difference between previous gold and new gold."""
         del end_status  # Unused
         del action  # Unused
-        if not self.env.in_normal_game():
+        if not self.nethack.in_normal_game():
             # Before game started or after it ended stats are zero.
             return 0.0
 
@@ -230,7 +230,7 @@ class NetHackEat(NetHackScore):
         del end_status  # Unused
         del action  # Unused
 
-        if not self.env.in_normal_game():
+        if not self.nethack.in_normal_game():
             # Before game started or after it ended stats are zero.
             return 0.0
 
@@ -262,7 +262,7 @@ class NetHackScout(NetHackScore):
         del end_status  # Unused
         del action  # Unused
 
-        if not self.env.in_normal_game():
+        if not self.nethack.in_normal_game():
             # Before game started or after it ended stats are zero.
             return 0.0
 
@@ -344,9 +344,9 @@ class NetHackChallenge(NetHackScore):
         def f(*args, **kwargs):
             raise RuntimeError("Should not try changing seeds")
 
-        self.env.set_initial_seeds = f
-        self.env.set_current_seeds = f
-        self.env.get_current_seeds = f
+        self.nethack.set_initial_seeds = f
+        self.nethack.set_current_seeds = f
+        self.nethack.get_current_seeds = f
 
     def reset(self, *args, **kwargs):
         self._turns = None

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -191,11 +191,11 @@ class Nethack:
 
         if options is None:
             options = NETHACKOPTIONS
-        self._options = list(options) + ["name:" + playername]
+        self.options = list(options) + ["name:" + playername]
         if wizard:
-            self._options.append("playmode:debug")
+            self.options.append("playmode:debug")
         self._wizard = wizard
-        self._nethackoptions = ",".join(self._options)
+        self._nethackoptions = ",".join(self.options)
         if ttyrec is None:
             self._pynethack = _pynethack.Nethack(
                 self.dlpath, self._vardir, self._nethackoptions, spawn_monsters

--- a/nle/tests/test_profile.py
+++ b/nle/tests/test_profile.py
@@ -52,7 +52,7 @@ class TestProfile:
         steps = 1000
 
         np.random.seed(seeds)
-        actions = np.random.choice(len(env._actions), size=steps)
+        actions = np.random.choice(env.action_space.n, size=steps)
 
         def seed():
             if not nle.nethack.NLE_ALLOW_SEEDING:


### PR DESCRIPTION
Fixes #273.

One reason this matters more than one would assume is that gym envs wrappers tend to forward non-underscore access but will typically fail with `._underscore` access. This happened e.g. for the 0.21 release which auto-wrapped every env.

Also a bit more cleanup.