### PR TITLE
Don't allow set_buffers to be called after reset.

### DIFF
--- a/nle/tests/test_nethack.py
+++ b/nle/tests/test_nethack.py
@@ -200,6 +200,12 @@ class TestNetHackFurther:
         with pytest.raises(IOError):
             game.reset("")
 
+    def test_set_buffers_after_reset(self):
+        game = nethack.Nethack()
+        game.reset()
+        with pytest.raises(RuntimeError, match=r"set_buffers called after reset()"):
+            game._pynethack.set_buffers()
+
 
 class TestNethackSomeObs:
     @pytest.fixture

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -178,6 +178,9 @@ class Nethack
                 py::object screen_descriptions, py::object tty_chars,
                 py::object tty_colors, py::object tty_cursor, py::object misc)
     {
+        if (nle_)
+            throw std::runtime_error("set_buffers called after reset()");
+
         std::vector<ssize_t> dungeon{ ROWNO, COLNO - 1 };
         obs_.glyphs = checked_conversion<int16_t>(glyphs, dungeon);
         obs_.chars = checked_conversion<uint8_t>(chars, dungeon);


### PR DESCRIPTION
This guarantees we write to the buffer from before and therefore
need to only update the delta, saving us a few memcopies potentially.

Fixes #133.