### PR TITLE
Pick random race/gender/alignment when selecting random role.

### DIFF
--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -192,7 +192,7 @@ class Nethack:
         if options is None:
             options = NETHACKOPTIONS
         self.options = list(options) + ["name:" + playername]
-        if playername.split("-", 1)[1] == "@":
+        if next(iter(playername.split("-", 1)[1:]), None) == "@":
             # Random role. Unless otherwise specified, randomize
             # race/gender/alignment too.
             for key in ("race", "gender", "align"):

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -192,7 +192,7 @@ class Nethack:
         if options is None:
             options = NETHACKOPTIONS
         self.options = list(options) + ["name:" + playername]
-        if next(iter(playername.split("-", 1)[1:]), None) == "@":
+        if "-" in playername and playername.split("-", 1)[1] == "@":
             # Random role. Unless otherwise specified, randomize
             # race/gender/alignment too.
             for key in ("race", "gender", "align"):

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -192,7 +192,7 @@ class Nethack:
         if options is None:
             options = NETHACKOPTIONS
         self.options = list(options) + ["name:" + playername]
-        if "-" in playername and playername.split("-", 1)[1] == "@":
+        if playername.split("-", 1)[1:] == ["@"]:
             # Random role. Unless otherwise specified, randomize
             # race/gender/alignment too.
             for key in ("race", "gender", "align"):

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -192,6 +192,13 @@ class Nethack:
         if options is None:
             options = NETHACKOPTIONS
         self.options = list(options) + ["name:" + playername]
+        if playername.split("-", 1)[1] == "@":
+            # Random role. Unless otherwise specified, randomize
+            # race/gender/alignment too.
+            for key in ("race", "gender", "align"):
+                if not next((o for o in options if o.startswith(key + ":")), False):
+                    self.options.append("%s:random" % key)
+
         if wizard:
             self.options.append("playmode:debug")
         self._wizard = wizard

--- a/nle/nethack/nethack.py
+++ b/nle/nethack/nethack.py
@@ -196,7 +196,7 @@ class Nethack:
             # Random role. Unless otherwise specified, randomize
             # race/gender/alignment too.
             for key in ("race", "gender", "align"):
-                if not next((o for o in options if o.startswith(key + ":")), False):
+                if not any(o for o in options if o.startswith(key + ":")):
                     self.options.append("%s:random" % key)
 
         if wizard:

--- a/nle/tests/test_nethack.py
+++ b/nle/tests/test_nethack.py
@@ -206,6 +206,26 @@ class TestNetHackFurther:
         with pytest.raises(RuntimeError, match=r"set_buffers called after reset()"):
             game._pynethack.set_buffers()
 
+    def test_nethack_random_character(self):
+        game = nethack.Nethack(playername="Hugo-@")
+        assert "race:random" in game.options
+        assert "gender:random" in game.options
+        assert "align:random" in game.options
+
+        game = nethack.Nethack(playername="Jurgen-wiz-gno-cha-mal")
+        assert "race:random" not in game.options
+        assert "gender:random" not in game.options
+        assert "align:random" not in game.options
+
+        game = nethack.Nethack(
+            playername="Albert-@",
+            options=list(nethack.NETHACKOPTIONS) + ["align:lawful"],
+        )
+        assert "race:random" in game.options
+        assert "gender:random" in game.options
+        assert "align:random" not in game.options
+        assert "align:lawful" in game.options
+
 
 class TestNethackSomeObs:
     @pytest.fixture

--- a/nle/tests/test_nethack.py
+++ b/nle/tests/test_nethack.py
@@ -226,6 +226,15 @@ class TestNetHackFurther:
         assert "align:random" not in game.options
         assert "align:lawful" in game.options
 
+        game = nethack.Nethack(
+            playername="Rachel",
+            options=list(nethack.NETHACKOPTIONS) + ["gender:female"],
+        )
+        assert "race:random" not in game.options
+        assert "gender:random" not in game.options
+        assert "align:random" not in game.options
+        assert "gender:female" in game.options
+
 
 class TestNethackSomeObs:
     @pytest.fixture


### PR DESCRIPTION
A NetHack option like "name:Heiner-@" only selects a random role but
still asks about race/gender/alignment. NetHack also has the command
line flag -@ (mapped to flags.randomall) to randomize everything,
but there's no option in the .nethackrc sense for that.

This change makes it such that playername="Heiner-@" appends
race:random, gender:random, align:random to NetHack's options unless
these have been set already.

Note: In the NetHack competition, this issue didn't hurt us because
we auto-selected "Random" for the startup questions.

Fixes #282.