### PR TITLE
Updates to cmake

### DIFF
--- a/dat/CMakeLists.txt
+++ b/dat/CMakeLists.txt
@@ -198,39 +198,41 @@ set(LEVS_GEN
     wizard3.lev)
 
 add_custom_command(
-  DEPENDS makedefs bogusmon.txt engrave.txt epitaph.txt
+  DEPENDS $<TARGET_FILE:makedefs> bogusmon.txt engrave.txt epitaph.txt
   OUTPUT bogusmon epitaph engrave
   COMMAND makedefs ARGS -s)
 
 add_custom_command(
-  DEPENDS makedefs data.base
+  DEPENDS $<TARGET_FILE:makedefs> data.base
   OUTPUT data
   COMMAND makedefs ARGS -d)
 
 add_custom_command(
-  DEPENDS makedefs rumors.tru rumors.fal
+  DEPENDS $<TARGET_FILE:makedefs> rumors.tru rumors.fal
   OUTPUT rumors
   COMMAND makedefs ARGS -r)
 
 add_custom_command(
-  DEPENDS makedefs quest.txt
+  DEPENDS $<TARGET_FILE:makedefs> quest.txt
   OUTPUT quest.dat
   COMMAND makedefs ARGS -q)
 
 add_custom_command(
-  DEPENDS makedefs oracles.txt
+  DEPENDS $<TARGET_FILE:makedefs> oracles.txt
   OUTPUT oracles
   COMMAND makedefs ARGS -h)
 
 # Hack: Depend on date.h to avoid race.
 add_custom_command(
-  DEPENDS makedefs ${NLE_INC_GEN}/date.h
+  DEPENDS $<TARGET_FILE:makedefs> ${NLE_INC_GEN}/date.h
   OUTPUT options
   COMMAND makedefs ARGS -v)
 
-# Hack: Depend on bogusmon to avoid race wrt. makedef's grep.tmp file.
+# Hack: Depend on bogusmon to avoid race wrt. makedef's grep.tmp file. Best to
+# be defensive about the paths (matters if NetHack's make install was run).
 add_custom_command(
-  DEPENDS makedefs dgn_comp dungeon.def bogusmon
+  DEPENDS $<TARGET_FILE:makedefs> $<TARGET_FILE:dgn_comp>
+          ${NLE_DAT_GEN}/dungeon.def ${NLE_DAT_GEN}/bogusmon
   OUTPUT dungeon dungeon.pdf
   COMMAND makedefs ARGS -e
   COMMAND dgn_comp ARGS dungeon.pdf)
@@ -245,8 +247,20 @@ add_custom_command(
   OUTPUT perm record logfile xlogfile COMMAND ${CMAKE_COMMAND} -E touch perm
                                               record logfile xlogfile)
 
+# Defensive dependencies for when we also build NetHack with make/make install.
+list(TRANSFORM DATDLB PREPEND ${NLE_DAT_GEN}/ OUTPUT_VARIABLE
+                                              NLE_DAT_GEN_DATDLB)
+list(TRANSFORM LEVS_GEN PREPEND ${NLE_DAT_GEN}/ OUTPUT_VARIABLE
+                                                NLE_DAT_GEN_LEVS_GEN)
+
+# Defensive dependencies for when we also build NetHack with make/make install.
+list(TRANSFORM DATDLB PREPEND ${NLE_DAT_GEN}/ OUTPUT_VARIABLE
+                                              NLE_DAT_GEN_DATDLB)
+list(TRANSFORM LEVS_GEN PREPEND ${NLE_DAT_GEN}/ OUTPUT_VARIABLE
+                                                NLE_DAT_GEN_LEVS_GEN)
+
 add_custom_command(
-  DEPENDS dlb ${DATDLB} ${LEVS_GEN}
+  DEPENDS dlb ${NLE_DAT_GEN_DATDLB} ${NLE_DAT_GEN_LEVS_GEN}
   OUTPUT nhdat
   COMMAND LC_ALL=C $<TARGET_FILE:dlb> ARGS cf nhdat ${DATDLB} ${LEVS_GEN})
 

--- a/dat/CMakeLists.txt
+++ b/dat/CMakeLists.txt
@@ -74,15 +74,7 @@ endforeach(filename)
 # Dat files that are not inputs to any tools.
 set(ALL_DAT_NOTGEN ${ALL_DAT_NOTGEN} license symbols)
 
-# TODO(NN): try to glob .lev automatically
-#
-# NOTE: Using:
-#
-# install(DIRECTORY ${NLE_DAT_GEN} DESTINATION ${INSTDIR} FILES_MATCHING PATTERN
-# "*.lev")
-#
-# results in `$HACKDIR/dat/*.lev` due to CWD. I've tried to get it to work, but
-# given up after a couple of hours.
+# Result of running lev_comp.
 set(LEVS_GEN
     Arc-fila.lev
     Arc-filb.lev
@@ -208,46 +200,46 @@ set(LEVS_GEN
 add_custom_command(
   DEPENDS makedefs bogusmon.txt engrave.txt epitaph.txt
   OUTPUT bogusmon epitaph engrave
-  COMMAND $<TARGET_FILE:makedefs> ARGS -s)
+  COMMAND makedefs ARGS -s)
 
 add_custom_command(
   DEPENDS makedefs data.base
   OUTPUT data
-  COMMAND $<TARGET_FILE:makedefs> ARGS -d)
+  COMMAND makedefs ARGS -d)
 
 add_custom_command(
   DEPENDS makedefs rumors.tru rumors.fal
   OUTPUT rumors
-  COMMAND $<TARGET_FILE:makedefs> ARGS -r)
+  COMMAND makedefs ARGS -r)
 
 add_custom_command(
   DEPENDS makedefs quest.txt
   OUTPUT quest.dat
-  COMMAND $<TARGET_FILE:makedefs> ARGS -q)
+  COMMAND makedefs ARGS -q)
 
 add_custom_command(
   DEPENDS makedefs oracles.txt
   OUTPUT oracles
-  COMMAND $<TARGET_FILE:makedefs> ARGS -h)
+  COMMAND makedefs ARGS -h)
 
 # Hack: Depend on date.h to avoid race.
 add_custom_command(
   DEPENDS makedefs ${NLE_INC_GEN}/date.h
   OUTPUT options
-  COMMAND $<TARGET_FILE:makedefs> ARGS -v)
+  COMMAND makedefs ARGS -v)
 
 # Hack: Depend on bogusmon to avoid race wrt. makedef's grep.tmp file.
 add_custom_command(
   DEPENDS makedefs dgn_comp dungeon.def bogusmon
   OUTPUT dungeon dungeon.pdf
-  COMMAND $<TARGET_FILE:makedefs> ARGS -e
-  COMMAND $<TARGET_FILE:dgn_comp> ARGS dungeon.pdf)
+  COMMAND makedefs ARGS -e
+  COMMAND dgn_comp ARGS dungeon.pdf)
 
 add_custom_command(
   DEPENDS lev_comp
   OUTPUT ${LEVS_GEN}
-  COMMAND $<TARGET_FILE:lev_comp> ${SPECIAL_LEVELS}
-  COMMAND $<TARGET_FILE:lev_comp> ${QUEST_LEVELS})
+  COMMAND lev_comp ${SPECIAL_LEVELS}
+  COMMAND lev_comp ${QUEST_LEVELS})
 
 add_custom_command(
   OUTPUT perm record logfile xlogfile COMMAND ${CMAKE_COMMAND} -E touch perm

--- a/dat/CMakeLists.txt
+++ b/dat/CMakeLists.txt
@@ -253,12 +253,6 @@ list(TRANSFORM DATDLB PREPEND ${NLE_DAT_GEN}/ OUTPUT_VARIABLE
 list(TRANSFORM LEVS_GEN PREPEND ${NLE_DAT_GEN}/ OUTPUT_VARIABLE
                                                 NLE_DAT_GEN_LEVS_GEN)
 
-# Defensive dependencies for when we also build NetHack with make/make install.
-list(TRANSFORM DATDLB PREPEND ${NLE_DAT_GEN}/ OUTPUT_VARIABLE
-                                              NLE_DAT_GEN_DATDLB)
-list(TRANSFORM LEVS_GEN PREPEND ${NLE_DAT_GEN}/ OUTPUT_VARIABLE
-                                                NLE_DAT_GEN_LEVS_GEN)
-
 add_custom_command(
   DEPENDS dlb ${NLE_DAT_GEN_DATDLB} ${NLE_DAT_GEN_LEVS_GEN}
   OUTPUT nhdat


### PR DESCRIPTION
This aligns our NLE cmake files with my proposal for a CMake-based NetHack-build, [here](https://github.com/NetHack/NetHack/pull/662) and [here](https://github.com/heiner/NetHack/tree/NetHack-3.6-cmake). In particular it adds some defensive measures when building NLE with cmake after building some artefacts with NetHack's Makefile setup.

The change in of not using `$<TARGET_FILE:...>` generators as the `COMMAND` of `add_custom_command` comes from [feedback from a PR for NetHack](https://github.com/NetHack/NetHack/pull/662#discussion_r793109922).