### PR TITLE
Fail if libnethack is resident before dlopening.

### DIFF
--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -10,7 +10,16 @@ void
 nledl_init(nledl_ctx *nledl, nle_obs *obs, nle_seeds_init_t *seed_init,
            nle_settings *settings)
 {
-    nledl->dlhandle = dlopen(nledl->dlpath, RTLD_LAZY);
+    void *handle = dlopen(nledl->dlpath, RTLD_LAZY | RTLD_NOLOAD);
+    if (handle) {
+        dlclose(handle);
+        fprintf(stderr,
+                "failure in nledl_init: library %s is already loaded\n",
+                nledl->dlpath);
+        exit(EXIT_FAILURE);
+    }
+
+    nledl->dlhandle = dlopen(nledl->dlpath, RTLD_LAZY | RTLD_FIRST);
 
     if (!nledl->dlhandle) {
         fprintf(stderr, "%s\n", dlerror());
@@ -50,7 +59,6 @@ nledl_close(nledl_ctx *nledl)
         fprintf(stderr, "Error in dlclose: %s\n", dlerror());
         exit(EXIT_FAILURE);
     }
-
     dlerror();
 }
 

--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -19,7 +19,7 @@ nledl_init(nledl_ctx *nledl, nle_obs *obs, nle_seeds_init_t *seed_init,
         exit(EXIT_FAILURE);
     }
 
-    nledl->dlhandle = dlopen(nledl->dlpath, RTLD_LAZY | RTLD_FIRST);
+    nledl->dlhandle = dlopen(nledl->dlpath, RTLD_LAZY);
 
     if (!nledl->dlhandle) {
         fprintf(stderr, "%s\n", dlerror());
@@ -59,6 +59,7 @@ nledl_close(nledl_ctx *nledl)
         fprintf(stderr, "Error in dlclose: %s\n", dlerror());
         exit(EXIT_FAILURE);
     }
+
     dlerror();
 }
 

--- a/sys/unix/rlmain.cc
+++ b/sys/unix/rlmain.cc
@@ -35,7 +35,6 @@ class ScopedTC
 void
 play(nledl_ctx *nle, nle_obs *obs, nle_settings *settings)
 {
-    char i;
     while (!obs->done) {
         for (int r = 0; r < ROWNO; ++r) {
             for (int c = 0; c < COLNO - 1; ++c)


### PR DESCRIPTION
This is the issue in #254.

This PR doesn't fix that issue but makes the error less mysterious. One hypothesis of the underlying cause is that all our copies of the .so have the same [dyld UUID](https://github.com/PureDarwin/dyld/blob/56cd028e61d0d487e5b604eb6bd2c5d577b24241/dyld3/MachOFile.cpp#L690), which is used for tracing in debug mode [causing](https://github.com/PureDarwin/dyld/blob/56cd028e61d0d487e5b604eb6bd2c5d577b24241/dyld3/ClosureBuilder.cpp#L370) the dl to be marked as [unloadable](https://github.com/PureDarwin/dyld/blob/56cd028e61d0d487e5b604eb6bd2c5d577b24241/dyld3/APIs.cpp#L816)