### PR TITLE
Add the filepath of the ttyrec if it exists to the xlogfile.

### DIFF
--- a/include/nleobs.h
+++ b/include/nleobs.h
@@ -94,6 +94,10 @@ typedef struct nle_settings {
      * https://nethackwiki.com/wiki/Monster_creation#Random_generation
      */
     int spawn_monsters;
+    /*
+     * Filename for nle's ttyrec*.bz2.
+     */
+    char ttyrecname[4096];
 } nle_settings;
 
 #endif /* NLEOBS_H */

--- a/src/nle.c
+++ b/src/nle.c
@@ -352,6 +352,12 @@ nle_done(int how)
     nle->observation->how_done = how;
 }
 
+char *
+nle_ttyrecname()
+{
+    return settings.ttyrecname;
+}
+
 int
 nle_spawn_monsters()
 {

--- a/src/topten.c
+++ b/src/topten.c
@@ -38,6 +38,9 @@ static long final_fpos;
 #define DTHSZ 100
 #define ROLESZ 3
 
+#define NLE_XLOG_INCLUDE_FILE
+extern char * FDECL(nle_ttyrecname, ());
+
 struct toptenentry {
     struct toptenentry *tt_next;
 #ifdef UPDATE_RECORD_IN_PLACE
@@ -376,6 +379,10 @@ int how;
             genders[flags.initgend].filecode, XLOG_SEP,
             aligns[1 - u.ualignbase[A_ORIGINAL]].filecode);
     Fprintf(rfile, "%cflags=0x%lx", XLOG_SEP, encodexlogflags());
+#ifdef NLE_XLOG_INCLUDE_FILE
+    if (nle_ttyrecname()[0] != '\0')
+        Fprintf(rfile, "%cttyrecname=%s", XLOG_SEP, nle_ttyrecname());
+#endif
     Fprintf(rfile, "\n");
 #undef XLOG_SEP
 }

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -341,6 +341,9 @@ class Nethack
     {
         py::gil_scoped_release gil;
 
+        if (!ttyrec)
+            strncpy(settings_.ttyrecname, "", sizeof(settings_.ttyrecname));
+
         if (!nle_) {
             nle_ =
                 nle_start(dlpath_.c_str(), &obs_, ttyrec ? ttyrec : ttyrec_,

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -122,6 +122,10 @@ class Nethack
         }
         strncpy(settings_.scoreprefix, scoreprefix.c_str(),
                 scoreprefix.length());
+        std::size_t found = ttyrec.rfind("/");
+        if (found != std::string::npos && found + 1 < ttyrec.length())
+            strncpy(settings_.ttyrecname, &ttyrec.c_str()[found + 1],
+                    ttyrec.length() - found - 1);
     }
 
     Nethack(std::string dlpath, std::string hackdir,
@@ -181,6 +185,12 @@ class Nethack
             PyErr_SetFromErrnoWithFilename(PyExc_OSError, ttyrec.c_str());
             throw py::error_already_set();
         }
+
+        std::size_t found = ttyrec.rfind("/");
+        if (found != std::string::npos && (found + 1) < ttyrec.length())
+            strncpy(settings_.ttyrecname, &ttyrec.c_str()[found + 1],
+                    ttyrec.length() - found - 1);
+
         // Reset environment, then close original FILE. Cannot use freopen
         // as the game may still need to write to the original file but
         // reset() wants to get the new one already.


### PR DESCRIPTION
This will make it easier for users to find which ttyrecs correspond to
which metadata.  Xlogfiles are only written to with natural endings; not
guaranteed if you call "reset" before "done" is ready. This means if
there is a panic and drop a game, you will not get alignment between
your ttyrec reset number and xlogfile row. This adds an explicit link.

NB: This only works because in nle (vs typical NetHack), we play the
whole game in _one_ ttyrec.