### PR TITLE
Adjust logging for populate db.

### DIFF
--- a/nle/dataset/db.py
+++ b/nle/dataset/db.py
@@ -5,13 +5,7 @@ import sqlite3
 import time
 
 DB = "ttyrecs.db"
-
-logging.basicConfig(
-    format=(
-        "[%(levelname)s:%(process)d %(module)s:%(lineno)d %(asctime)s] " "%(message)s"
-    ),
-    level=0,
-)
+logger = logging.getLogger("db")
 
 
 @contextlib.contextmanager
@@ -39,7 +33,7 @@ def ls(conn=None):
         c = conn.cursor()
         c.execute("SELECT * FROM meta")
         ctime, mtime = c.fetchone()
-        logging.info(
+        logger.info(
             time.ctime(ctime),
             time.ctime(mtime),
         )
@@ -175,7 +169,7 @@ def create(filename=DB):
     ctime = time.time()
 
     with db(filename=filename, new=True) as conn:
-        logging.info("Creating '%s' ...", DB)
+        logger.info("Creating '%s' ...", DB)
         c = conn.cursor()
 
         c.execute(
@@ -253,7 +247,7 @@ def create(filename=DB):
         )
 
         conn.commit()
-    logging.info(
+    logger.info(
         "Created Empty '%s'. Size: %.2f MB",
         filename,
         os.path.getsize(filename) / 1024**2,

--- a/nle/dataset/populate_db.py
+++ b/nle/dataset/populate_db.py
@@ -1,7 +1,6 @@
 import collections
 import datetime
 import glob
-import logging
 import os
 import time
 
@@ -51,7 +50,7 @@ def altorg_filename_to_timestamp(filename):
         this_datetime = this_date + this_time
         ts = datetime.datetime(*this_datetime)
     except ValueError:
-        logging.info("Skipping: '%s'" % filename)
+        print("Skipping: '%s'" % filename)
         return -1
     return ts.replace(tzinfo=datetime.timezone.utc).timestamp()
 
@@ -129,7 +128,7 @@ def add_altorg_directory(path, name, filename=db.DB):
     """
 
     with db.db(filename=filename, rw=True) as conn:
-        logging.info("Adding dataset '%s' ('%s') to '%s' " % (name, path, filename))
+        print("Adding dataset '%s' ('%s') to '%s' " % (name, path, filename))
 
         root = os.path.abspath(path)
         stime = time.time()
@@ -153,7 +152,7 @@ def add_altorg_directory(path, name, filename=db.DB):
 
             gameids = db.get_most_recent_games(c.rowcount, conn=c)
             db.add_games(name, *gameids, conn=c, commit=False)
-            logging.info("Found %i games in '%s'" % (len(gameids), xlogfile))
+            print("Found %i games in '%s'" % (len(gameids), xlogfile))
 
         # 3. Find all the (unblacklisted) ttyrecs belonging to each player
         #    and all the games belonging to each player.
@@ -172,7 +171,7 @@ def add_altorg_directory(path, name, filename=db.DB):
 
         # 4. Attempt assign each player's ttyrecs to each player's games.
         #    If successful, insert into `ttyrecs` table
-        logging.info("Matching up ttyrecs to games...")
+        print("Matching up ttyrecs to games...")
         empty_games = []
         for pname in ttyrecs_dict.keys():
             assigned = assign_ttyrecs_to_games(ttyrecs_dict[pname], games_dict[pname])
@@ -210,16 +209,13 @@ def add_altorg_directory(path, name, filename=db.DB):
 
         # 7. Commit and wrap up (optimize the db).
         conn.commit()
-        logging.info("Optimizing DB...")
+        print("Optimizing DB...")
         db.vacuum(conn=conn)
         games_added = db.count_games(name, conn=conn)
 
-    logging.info(
-        "Updated '%s' in %.2f sec. Size: %.2f MB, Games: %i",
-        filename,
-        mtime - stime,
-        os.path.getsize(filename) / 1024**2,
-        games_added,
+    print(
+        "Updated '%s' in %.2f sec. Size: %.2f MB, Games: %i"
+        % (filename, mtime - stime, os.path.getsize(filename) / 1024**2, games_added)
     )
 
 
@@ -248,7 +244,7 @@ def add_nledata_directory(path, name, filename=db.DB):
     from an empty database, regardless of environment.
     """
     with db.db(filename=filename, rw=True) as conn:
-        logging.info("Adding dataset '%s' ('%s') to '%s' " % (name, path, filename))
+        print("Adding dataset '%s' ('%s') to '%s' " % (name, path, filename))
 
         root = os.path.abspath(path)
         stime = time.time()
@@ -313,12 +309,9 @@ def add_nledata_directory(path, name, filename=db.DB):
         db.vacuum(conn=conn)
         games_added = db.count_games(name, conn=conn)
 
-    logging.info(
-        "Updated '%s' in %.2f sec. Size: %.2f MB, Games: %i",
-        filename,
-        mtime - stime,
-        os.path.getsize(filename) / 1024**2,
-        games_added,
+    print(
+        "Updated '%s' in %.2f sec. Size: %.2f MB, Games: %i"
+        % (filename, mtime - stime, os.path.getsize(filename) / 1024**2, games_added)
     )
 
 


### PR DESCRIPTION
We adjust the logging for db.py to be with a specific logger, and
populate_db methods now print. This is because populate methods should
happen very infrequently and should be logged loudly.