### PR TITLE
Pin gym to 0.23.0 temporarily.

### DIFF
--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -413,7 +413,7 @@ class TestEnvMisc:
             e = gym.make("NetHackScore-v0")
         else:
             # gym 0.24+ doesnt like the shape of our observations.
-            e = gym.make("NetHackScore-v0", disable_env_checker=True)
+            e = gym.make("NetHackScore-v0")
         try:
             yield e
         finally:

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ if __name__ == "__main__":
         ext_modules=[setuptools.Extension("nle", sources=[])],
         cmdclass={"build_ext": CMakeBuild},
         setup_requires=["pybind11>=2.2"],
-        install_requires=["pybind11>=2.2", "numpy>=1.16", "gym>=0.15"],
+        install_requires=["pybind11>=2.2", "numpy>=1.16", "gym>=0.15,<=0.23"],
         extras_require=extras_deps,
         python_requires=">=3.5",
         classifiers=[


### PR DESCRIPTION
NLE's interface does not pass new gym 0.24.0s checks. We temporarily
pin version while fix is in place.