### PR TITLE
Add an `exists` method

### DIFF
--- a/nle/dataset/db.py
+++ b/nle/dataset/db.py
@@ -21,6 +21,10 @@ def db(conn=None, filename=DB, new=False, rw=None, **kwargs):
             conn.close()
 
 
+def exists(filename=DB):
+    return os.path.exists(filename)
+
+
 def connect(filename=DB, new=False, rw=None, **kwargs):
     assert new ^ os.path.exists(filename)
     if not new and not rw:


### PR DESCRIPTION
Maybe this is overkill, but i think it enables a good idiom:

```python
import nle.dataset as nld

if not nld.db.exists():
    nld.db.create()
    nld.add_nledata_directory(path_to_dir, name)
```