### PR TITLE
Enable the choice of action space

### DIFF
--- a/nle/env/tasks.py
+++ b/nle/env/tasks.py
@@ -323,11 +323,12 @@ class NetHackChallenge(NetHackScore):
         no_progress_timeout: int = 10_000,
         **kwargs,
     ):
-        actions = nethack.ACTIONS
         kwargs["wizard"] = False
+        # this allows to select a different action space
+        # if the action space is not set, pick all the actions
+        if "actions" not in kwargs: kwargs["actions"] = nethack.ACTIONS
         super().__init__(
             *args,
-            actions=actions,
             character=character,
             allow_all_yn_questions=allow_all_yn_questions,
             allow_all_modes=allow_all_modes,


### PR DESCRIPTION
This fixes an error occurring when specifying an action space in the creation of the environment.
To reproduce the error:

```
actions = tuple(nle.nethack.CompassDirection)
env = gym.make('NetHackChallenge-v0', actions=actions)
```

Error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/lquarantiello/miniconda3/envs/nle/lib/python3.8/site-packages/gym/envs/registration.py", line 676, in make
    return registry.make(id, **kwargs)
  File "/home/lquarantiello/miniconda3/envs/nle/lib/python3.8/site-packages/gym/envs/registration.py", line 520, in make
    return spec.make(**kwargs)
  File "/home/lquarantiello/miniconda3/envs/nle/lib/python3.8/site-packages/gym/envs/registration.py", line 140, in make
    env = cls(**_kwargs)
  File "/home/lquarantiello/miniconda3/envs/nle/lib/python3.8/site-packages/nle/env/tasks.py", line 328, in __init__
    super().__init__(
TypeError: __init__() got multiple values for keyword argument 'actions'
```
