### PR TITLE
Save and load game

### DIFF
--- a/include/nledl.h
+++ b/include/nledl.h
@@ -28,4 +28,6 @@ void nle_end(nledl_ctx *);
 void nle_set_seed(nledl_ctx *, unsigned long, unsigned long, char);
 void nle_get_seed(nledl_ctx *, unsigned long *, unsigned long *, char *);
 
+int nle_save(nledl_ctx *);
+
 #endif /* NLEDL_H */

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -521,6 +521,9 @@ class NLE(gym.Env):
 
         return super().render(mode=mode)
 
+    def save(self, gamesavedir=None):
+        return self.nethack.save(gamesavedir=gamesavedir)
+
     def __repr__(self):
         return "<%s>" % self.__class__.__name__
 

--- a/nle/env/base.py
+++ b/nle/env/base.py
@@ -193,6 +193,8 @@ class NLE(gym.Env):
         allow_all_yn_questions=False,
         allow_all_modes=False,
         spawn_monsters=True,
+        gamesavedir=None,
+        gameloaddir=None,
     ):
         """Constructs a new NLE environment.
 
@@ -308,6 +310,8 @@ class NLE(gym.Env):
             wizard=wizard,
             spawn_monsters=spawn_monsters,
             scoreprefix=scoreprefix,
+            gamesavedir=gamesavedir,
+            gameloaddir=gameloaddir,
         )
         self._close_nethack = weakref.finalize(self, self.nethack.close)
 

--- a/nle/tests/test_envs.py
+++ b/nle/tests/test_envs.py
@@ -342,7 +342,27 @@ class TestGymEnvRollout:
             assert isinstance(output, str)
             assert len(output.replace("\n", "")) == np.prod(nle.env.DUNGEON_SHAPE)
 
+    def test_save_and_load(self, env_name, rollout_len):
+        """Tests rollout_len steps (or until termination) of random policy."""
+        with tempfile.TemporaryDirectory() as gamesavedir:
+            env = gym.make(env_name, gamesavedir=gamesavedir)
+        
+            obs = env.reset()
+            for _ in range(rollout_len):
+                action = env.action_space.sample()
+                obs, _, done, _ = env.step(action)
+                if done:
+                    obs = env.reset()
+            
+            env.save()
 
+            env = gym.make(env_name, gameloaddir=gamesavedir)
+            obsload = env.reset()
+
+            assert (obsload["blstats"] == obs["blstats"]).all()
+            assert (obsload["glyphs"] == obs["glyphs"]).all()
+
+        
 class TestGymDynamics:
     """Tests a few game dynamics."""
 

--- a/sys/unix/nledl.c
+++ b/sys/unix/nledl.c
@@ -150,3 +150,16 @@ nle_get_seed(nledl_ctx *nledl, unsigned long *core, unsigned long *disp,
     get_seed(nledl->nle_ctx, core, disp, reseed);
 }
 #endif
+
+
+int 
+nle_save(nledl_ctx *nledl)
+{   
+    int success;
+    void *(*dosave0)();
+
+    dosave0 = dlsym(nledl->dlhandle, "dosave0");
+    success = dosave0();
+
+    return success;
+}

--- a/win/rl/pynethack.cc
+++ b/win/rl/pynethack.cc
@@ -101,6 +101,10 @@ checked_conversion(py::handle h, const std::vector<ssize_t> &shape)
 class Nethack
 {
   public:
+    int save() {
+        return nle_save(nle_);
+    }
+
     Nethack(std::string dlpath, std::string ttyrec, std::string hackdir,
             std::string nethackoptions, bool spawn_monsters,
             std::string scoreprefix)
@@ -404,6 +408,7 @@ PYBIND11_MODULE(_pynethack, m)
         .def("get_seeds", &Nethack::get_seeds)
         .def("in_normal_game", &Nethack::in_normal_game)
         .def("how_done", &Nethack::how_done)
+        .def("save", &Nethack::save)
         .def("set_wizkit", &Nethack::set_wizkit);
 
     py::module mn = m.def_submodule(


### PR DESCRIPTION
### Summary

This PR adds the ability to save and load game state for environments. This allows games to be paused and resumed from the saved state. 

This leverages how save scumming can be done, as described here https://nethackwiki.com/wiki/Save_scumming
basically all the files from HACKDIR are copied to separate directory. Then if someone wants to load the game it's enough to copy back the files and create new nethack game. Unfortunately game has to be turned off and on to do so. 

Disclaimer: I am not sure if my changes in `_new_dl` don't break something else, I don't really understand what is happening there and why.

### Example usage (from added test)
```    
    def test_save_and_load(self, env_name, rollout_len):
        """Tests rollout_len steps (or until termination) of random policy."""
        with tempfile.TemporaryDirectory() as gamesavedir:
            env = gym.make(env_name, gamesavedir=gamesavedir)

            obs = env.reset()
            for _ in range(rollout_len):
                action = env.action_space.sample()
                obs, _, done, _ = env.step(action)
                if done:
                    obs = env.reset()

            env.save()

            env = gym.make(env_name, gameloaddir=gamesavedir)
            obsload = env.reset()

            assert (obsload["blstats"] == obs["blstats"]).all()
            assert (obsload["glyphs"] == obs["glyphs"]).all()
```

### Use cases 
I used this to evaluate trained agents starting from different levels in the dungeon. For example Sokoban https://nethackwiki.com/wiki/Sokoban. I thought I could share my code and contribute back to the community. 